### PR TITLE
Reduce Web UI render overhead by reusing RbelHtmlRenderingToolkit

### DIFF
--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/controller/TigerWebUiController.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/controller/TigerWebUiController.java
@@ -256,6 +256,12 @@ public class TigerWebUiController implements ApplicationContextAware {
         .execute();
   }
 
+  private static String renderMessageWithReset(
+      RbelHtmlRenderingToolkit renderingToolkit, RbelElement msg) {
+    renderingToolkit.resetForNewMessage();
+    return renderingToolkit.convertMessage(msg).render();
+  }
+
   /** Returns a stable hash, even if the message queue is empty. */
   private String messageHash() {
     var messages = getTigerProxy().getRbelMessages();
@@ -295,6 +301,7 @@ public class TigerWebUiController implements ApplicationContextAware {
 
     var messageStream = messages.stream();
     messageStream = filterMessages(messageStream, filterRbelPath);
+    var renderingToolkit = new RbelHtmlRenderingToolkit(renderer);
 
     result.setMessages(
         messageStream
@@ -304,7 +311,7 @@ public class TigerWebUiController implements ApplicationContextAware {
                 msg ->
                     HtmlMessageScrollableDto.builder()
                         .content(
-                            new RbelHtmlRenderingToolkit(renderer).convertMessage(msg).render())
+                            renderMessageWithReset(renderingToolkit, msg))
                         .uuid(msg.getUuid())
                         .sequenceNumber(MessageMetaDataDto.getElementSequenceNumber(msg))
                         .build())

--- a/tiger-rbel/src/main/java/de/gematik/rbellogger/renderer/RbelHtmlRenderingToolkit.java
+++ b/tiger-rbel/src/main/java/de/gematik/rbellogger/renderer/RbelHtmlRenderingToolkit.java
@@ -114,6 +114,10 @@ public class RbelHtmlRenderingToolkit {
         false);
   }
 
+  public void resetForNewMessage() {
+    noteTags.clear();
+  }
+
   public RbelHtmlRenderingToolkit withInShortenedRenderingMode(boolean inShortenedRenderingMode) {
     if (this.inShortenedRenderingMode == inShortenedRenderingMode) {
       return this;
@@ -478,7 +482,14 @@ public class RbelHtmlRenderingToolkit {
                                             "created fst-italic " + isSize(6) + " float-end me-6"),
                                     div()
                                         .withClass("rbel-main-content")
-                                        .with(elements.stream().map(this::convertMessage).toList()),
+                                        .with(
+                                            elements.stream()
+                                                .map(
+                                                    element -> {
+                                                      resetForNewMessage();
+                                                      return convertMessage(element);
+                                                    })
+                                                .toList()),
                                     div("Created "
                                             + DateTimeFormatter.RFC_1123_DATE_TIME.format(
                                                 ZonedDateTime.now()))


### PR DESCRIPTION
- Reused a single RbelHtmlRenderingToolkit per ``/getMessagesWithHtml`` request instead of constructing a new one per message, and added a reset hook to clear per‑message JSON note tags. This reduces object churn and prevents note tag accumulation across messages.
- Ensured full HTML document rendering resets the note tags between messages too, so output stays correct and memory stays bounded.

Why this works for performance:

- The toolkit holds an ObjectMapper and a noteTags map that grows during rendering. Creating a new toolkit for every message or letting noteTags grow across messages increases allocations and GC pressure.
- Reusing one toolkit per request avoids repeated heavyweight instantiation.
- Resetting noteTags before each message keeps memory bounded and prevents mismatched note replacements across messages, preserving correct rendering.