### PR TITLE
Avoid repeated child lookups when rendering JSON facets

### DIFF
--- a/tiger-rbel/src/main/java/de/gematik/rbellogger/renderer/RbelHtmlRenderingToolkit.java
+++ b/tiger-rbel/src/main/java/de/gematik/rbellogger/renderer/RbelHtmlRenderingToolkit.java
@@ -600,6 +600,13 @@ public class RbelHtmlRenderingToolkit {
               .build());
       output.put("note", uuid.toString());
     }
+    // Cache first child per key to avoid repeated child traversal for each field.
+    final Map<String, RbelElement> firstChildByKey = new HashMap<>();
+    for (Entry<String, RbelElement> entry : originalElement.getChildNodesWithKey().entries()) {
+      if (entry.getValue() != null) {
+        firstChildByKey.putIfAbsent(entry.getKey(), entry.getValue());
+      }
+    }
     for (Iterator<Entry<String, JsonNode>> it = input.fields(); it.hasNext(); ) {
       Entry<String, JsonNode> element = it.next();
       output.set(
@@ -607,8 +614,7 @@ public class RbelHtmlRenderingToolkit {
           shadeJson(
               element.getValue(),
               Optional.of(element.getKey()),
-              originalElement
-                  .getFirst(element.getKey())
+              Optional.ofNullable(firstChildByKey.get(element.getKey()))
                   .orElseThrow(
                       () ->
                           new RuntimeException(


### PR DESCRIPTION
## Problem
JSON rendering repeatedly calls `getFirst(...)` for each field, which rebuilds child-node data each time and adds overhead on large objects.

## Change
Cache the first child per key once per object render and reuse it while shading JSON fields.

## Impact
Reduces repeated traversal/allocation during JSON rendering without changing output.