### PR TITLE
Skip TestEnvMgr web stack when UI features are off

### DIFF
--- a/tiger-testenv-mgr/src/main/java/de/gematik/test/tiger/testenvmgr/controller/UpdateLogController.java
+++ b/tiger-testenv-mgr/src/main/java/de/gematik/test/tiger/testenvmgr/controller/UpdateLogController.java
@@ -27,11 +27,16 @@ import de.gematik.test.tiger.testenvmgr.servers.TigerServerLogUpdate;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnExpression(
+    "${tiger.lib.activateWorkflowUi:false} || ${tiger.lib.trafficVisualization:false}")
 @RequiredArgsConstructor
 public class UpdateLogController implements TigerServerLogListener {
 

--- a/tiger-testenv-mgr/src/main/java/de/gematik/test/tiger/testenvmgr/controller/UpdatePushConfiguration.java
+++ b/tiger-testenv-mgr/src/main/java/de/gematik/test/tiger/testenvmgr/controller/UpdatePushConfiguration.java
@@ -21,6 +21,8 @@
 package de.gematik.test.tiger.testenvmgr.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -33,6 +35,9 @@ import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnExpression(
+    "${tiger.lib.activateWorkflowUi:false} || ${tiger.lib.trafficVisualization:false}")
 @RequiredArgsConstructor
 public class UpdatePushConfiguration implements WebSocketMessageBrokerConfigurer {
 

--- a/tiger-testenv-mgr/src/main/java/de/gematik/test/tiger/testenvmgr/controller/UpdatePushController.java
+++ b/tiger-testenv-mgr/src/main/java/de/gematik/test/tiger/testenvmgr/controller/UpdatePushController.java
@@ -27,11 +27,16 @@ import de.gematik.test.tiger.testenvmgr.env.TigerUpdateListener;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnExpression(
+    "${tiger.lib.activateWorkflowUi:false} || ${tiger.lib.trafficVisualization:false}")
 @RequiredArgsConstructor
 public class UpdatePushController implements TigerUpdateListener {
 


### PR DESCRIPTION
## Summary
Avoid starting the embedded servlet/websocket stack when the test run doesn’t need the Workflow UI or REST endpoints, gate websocket push components to UI/traffic features only.
## Rationale 
Reduces testsuite startup time by removing servlet and STOMP broker initialization in headless runs.