### PR TITLE
Enable deleteAfterNExecutions

### DIFF
--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/controller/TigerModificationController.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/controller/TigerModificationController.java
@@ -50,6 +50,7 @@ public class TigerModificationController {
                 .targetElement(addModificationDto.getTargetElement())
                 .replaceWith(addModificationDto.getReplaceWith())
                 .regexFilter(addModificationDto.getRegexFilter())
+                .deleteAfterNExecutions(addModificationDto.getDeleteAfterNExecutions())
                 .build());
     return ModificationDto.from(modification);
   }

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/data/ModificationDto.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/data/ModificationDto.java
@@ -37,6 +37,7 @@ public class ModificationDto {
   private String targetElement;
   private String replaceWith;
   private String regexFilter;
+  private Integer deleteAfterNExecutions;
 
   public static ModificationDto from(RbelModificationDescription modification) {
     return ModificationDto.builder()

--- a/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/TigerProxyModificationControllerTest.java
+++ b/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/TigerProxyModificationControllerTest.java
@@ -82,6 +82,7 @@ class TigerProxyModificationControllerTest {
             .condition("isRequest")
             .targetElement("$.header.user-agent")
             .replaceWith("modified user-agent")
+            .deleteAfterNExecutions(5)
             .build();
     tigerRemoteProxyClient.addModificaton(modificationDescription);
 
@@ -91,6 +92,7 @@ class TigerProxyModificationControllerTest {
     assertThat(modification.getCondition()).isEqualTo("isRequest");
     assertThat(modification.getTargetElement()).isEqualTo("$.header.user-agent");
     assertThat(modification.getReplaceWith()).isEqualTo("modified user-agent");
+    assertThat(modification.getDeleteAfterNExecutions()).isEqualTo(5);
   }
 
   @Test


### PR DESCRIPTION
Um Manipulationen effektiv einzusetzen ist es notwendig die Anzahl der Ausführungen anzugeben. Diese Funktionalität ist bereits vorhanden und nur der Controller muss entsprechend erweitert werden