### PR TITLE
tiger-proxy: add IPv4 fallback for remote traffic endpoints

### DIFF
--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/AbstractTigerProxy.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/AbstractTigerProxy.java
@@ -38,6 +38,11 @@ import de.gematik.test.tiger.proxy.exceptions.TigerProxyStartupException;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyPair;
@@ -45,10 +50,12 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import kong.unirest.core.Unirest;
 import lombok.*;
@@ -310,9 +317,22 @@ public abstract class AbstractTigerProxy implements ITigerProxy, AutoCloseable {
     rbelMessageListeners.remove(listener);
   }
 
-  protected void waitForRemoteTigerProxyToBeOnline(String url) {
-    LocalDateTime pollingStart = LocalDateTime.now();
-    while (!isShuttingDown && !isGivenTigerProxyHealthy(url)) {
+  protected String waitForRemoteTigerProxyToBeOnline(String url) {
+    final var candidateUrls = expandUrlWithIpv4Candidates(url);
+    final var pollingStart = LocalDateTime.now();
+    while (!isShuttingDown) {
+      final var reachableCandidate =
+          candidateUrls.stream().filter(this::isGivenTigerProxyHealthy).findFirst();
+      if (reachableCandidate.isPresent()) {
+        final var candidateUrl = reachableCandidate.get();
+        if (!candidateUrl.equals(url)) {
+          log.info(
+              "Remote proxy endpoint '{}' not reachable, using IPv4 fallback '{}'",
+              url,
+              candidateUrl);
+        }
+        return candidateUrl;
+      }
       try {
         Thread.sleep(500);
       } catch (InterruptedException e) {
@@ -328,6 +348,57 @@ public abstract class AbstractTigerProxy implements ITigerProxy, AutoCloseable {
     }
     if (isShuttingDown) {
       log.warn("Aborting waitForRemoteTigerProxyToBeOnline at '{}'", url);
+      return url;
+    }
+    return url;
+  }
+
+  static List<String> expandUrlWithIpv4Candidates(String url) {
+    final var candidateUrls = new LinkedHashSet<String>();
+    candidateUrls.add(url);
+
+    final URI uri;
+    try {
+      uri = URI.create(url);
+    } catch (IllegalArgumentException e) {
+      return List.copyOf(candidateUrls);
+    }
+
+    final var host = uri.getHost();
+    if (StringUtils.isBlank(host) || isIpLiteral(host)) {
+      return List.copyOf(candidateUrls);
+    }
+
+    try {
+      candidateUrls.addAll(
+          List.of(InetAddress.getAllByName(host)).stream()
+              .filter(Inet4Address.class::isInstance)
+              .map(InetAddress::getHostAddress)
+              .map(ipv4Address -> replaceHost(uri, ipv4Address))
+              .collect(Collectors.toCollection(LinkedHashSet::new)));
+    } catch (UnknownHostException e) {
+      return List.copyOf(candidateUrls);
+    }
+    return List.copyOf(candidateUrls);
+  }
+
+  private static boolean isIpLiteral(String host) {
+    return host.contains(":") || host.matches("\\d+\\.\\d+\\.\\d+\\.\\d+");
+  }
+
+  private static String replaceHost(URI uri, String newHost) {
+    try {
+      return new URI(
+              uri.getScheme(),
+              uri.getUserInfo(),
+              newHost,
+              uri.getPort(),
+              uri.getPath(),
+              uri.getQuery(),
+              uri.getFragment())
+          .toString();
+    } catch (URISyntaxException e) {
+      return uri.toString();
     }
   }
 

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClient.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClient.java
@@ -81,6 +81,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
   public static final String WS_DATA = "/topic/data";
   public static final String WS_ERRORS = "/topic/errors";
   @Getter private final String remoteProxyUrl;
+  @Getter private String connectedRemoteProxyUrl;
   private final WebSocketStompClient tigerProxyStompClient;
 
   @Getter private final List<TigerExceptionDto> receivedRemoteExceptions = new ArrayList<>();
@@ -124,6 +125,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
       @Nullable TigerProxy masterTigerProxy) {
     super(configuration, masterTigerProxy == null ? null : masterTigerProxy.getRbelLogger());
     this.remoteProxyUrl = remoteProxyUrl;
+    this.connectedRemoteProxyUrl = remoteProxyUrl;
     this.masterTigerProxy = masterTigerProxy;
     this.binaryChunksBuffer =
         new MultipleBinaryConnectionParser(
@@ -185,12 +187,12 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
     if (isShuttingDown()) {
       return;
     }
-    waitForRemoteTigerProxyToBeOnline(remoteProxyUrl);
+    connectedRemoteProxyUrl = waitForRemoteTigerProxyToBeOnline(remoteProxyUrl);
     if (isShuttingDown()) {
       return;
     }
-    log.info("remote proxy at {} is online, now connecting...", remoteProxyUrl);
-    final String tracingWebSocketUrl = getTracingWebSocketUrl(remoteProxyUrl);
+    log.info("remote proxy at {} is online, now connecting...", connectedRemoteProxyUrl);
+    final var tracingWebSocketUrl = getTracingWebSocketUrl(connectedRemoteProxyUrl);
     tigerProxyStompClient
         .connectAsync(tracingWebSocketUrl, tigerStompSessionHandler)
         .orTimeout(connectionTimeoutInSeconds, TimeUnit.SECONDS)
@@ -204,12 +206,13 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
                   () -> {
                     log.info(
                         "Connected to remote proxy at {}, now downloading traffic...",
-                        remoteProxyUrl);
+                        connectedRemoteProxyUrl);
                     if (downloadTraffic) {
                       downloadTrafficFromRemoteProxy();
                     }
                     log.info(
-                        "Successfully downloaded traffic from remote proxy at {}", remoteProxyUrl);
+                        "Successfully downloaded traffic from remote proxy at {}",
+                        connectedRemoteProxyUrl);
                   });
               return stompSessionInCallback;
             })
@@ -224,7 +227,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public TigerProxyRoute addRoute(TigerProxyRoute tigerRoute) {
-    return Unirest.put(remoteProxyUrl + "/route")
+    return Unirest.put(getBaseUrl() + "/route")
         .body(tigerRoute)
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .asObject(TigerProxyRoute.class)
@@ -243,8 +246,8 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
   public void removeRoute(String routeId) {
     Assert.hasText(routeId, () -> "No route ID given!");
 
-    final Optional<Boolean> isInternalOptional =
-        Unirest.get(remoteProxyUrl + "/route")
+    final var isInternalOptional =
+        Unirest.get(getBaseUrl() + "/route")
             .asObject(new GenericType<List<TigerProxyRoute>>() {})
             .getBody()
             .stream()
@@ -260,7 +263,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
           "Could not delete route with id '" + routeId + "': Is internal route!");
     }
 
-    Unirest.delete(remoteProxyUrl + "/route/" + routeId)
+    Unirest.delete(getBaseUrl() + "/route/" + routeId)
         .asString()
         .ifFailure(
             httpResponse -> {
@@ -271,7 +274,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public void clearAllRoutes() {
-    Unirest.get(remoteProxyUrl + "/route")
+    Unirest.get(getBaseUrl() + "/route")
         .asObject(new GenericType<List<TigerProxyRoute>>() {})
         .getBody()
         .stream()
@@ -282,7 +285,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public String getBaseUrl() {
-    return remoteProxyUrl;
+    return connectedRemoteProxyUrl;
   }
 
   @Override
@@ -292,7 +295,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public List<TigerProxyRoute> getRoutes() {
-    return Unirest.get(remoteProxyUrl + "/route")
+    return Unirest.get(getBaseUrl() + "/route")
         .asObject(new GenericType<List<TigerProxyRoute>>() {})
         .ifFailure(
             response -> {
@@ -307,7 +310,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public RbelModificationDescription addModificaton(RbelModificationDescription modification) {
-    return Unirest.put(remoteProxyUrl + "/modification")
+    return Unirest.put(getBaseUrl() + "/modification")
         .body(modification)
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .asObject(RbelModificationDescription.class)
@@ -324,7 +327,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public List<RbelModificationDescription> getModifications() {
-    return Unirest.get(remoteProxyUrl + "/modification")
+    return Unirest.get(getBaseUrl() + "/modification")
         .asObject(new GenericType<List<RbelModificationDescription>>() {})
         .ifFailure(
             response -> {
@@ -340,7 +343,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
   @Override
   public void removeModification(String modificationName) {
     Assert.hasText(modificationName, () -> "No modification name given!");
-    Unirest.delete(remoteProxyUrl + "/modification/" + modificationName)
+    Unirest.delete(getBaseUrl() + "/modification/" + modificationName)
         .asEmpty()
         .ifFailure(
             httpResponse -> {

--- a/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/AbstractTigerProxyIpv4FallbackTest.java
+++ b/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/AbstractTigerProxyIpv4FallbackTest.java
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright 2021-2025 gematik GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * *******
+ *
+ * For additional notes and disclaimer from gematik and in case of changes by gematik find details in the "Readme" file.
+ */
+package de.gematik.test.tiger.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AbstractTigerProxyIpv4FallbackTest {
+
+  @Test
+  void expandUrlWithIpv4Candidates_shouldKeepOriginalUrlFirst() {
+    List<String> candidates =
+        AbstractTigerProxy.expandUrlWithIpv4Candidates("http://localhost:8080/tracing");
+
+    assertThat(candidates).isNotEmpty();
+    assertThat(candidates.get(0)).isEqualTo("http://localhost:8080/tracing");
+  }
+
+  @Test
+  void expandUrlWithIpv4Candidates_shouldAddIpv4VariantForLocalhost() {
+    List<String> candidates =
+        AbstractTigerProxy.expandUrlWithIpv4Candidates("http://localhost:8080/tracing");
+
+    assertThat(candidates).contains("http://127.0.0.1:8080/tracing");
+  }
+
+  @Test
+  void expandUrlWithIpv4Candidates_shouldNotExpandIpLiterals() {
+    assertThat(AbstractTigerProxy.expandUrlWithIpv4Candidates("http://127.0.0.1:8080/tracing"))
+        .containsExactly("http://127.0.0.1:8080/tracing");
+
+    assertThat(AbstractTigerProxy.expandUrlWithIpv4Candidates("http://[::1]:8080/tracing"))
+        .containsExactly("http://[::1]:8080/tracing");
+  }
+}


### PR DESCRIPTION
## Summary

  This change removes the need for forcing `-Djava.net.preferIPv4Stack=true` in test suites that subscribe
  to remote Tiger proxy traffic endpoints.

  When a configured traffic endpoint host (for example `localhost`) resolves to IPv6 first in some
  environments (notably WSL/dual-stack setups), the current client may fail to connect even though IPv4 is
  reachable.

  ## What changed

  - Added remote endpoint candidate expansion in `AbstractTigerProxy`:
    - keep original URL first
    - resolve hostname and append IPv4 host candidates
  - `waitForRemoteTigerProxyToBeOnline(...)` now:
    - checks candidates in order
    - returns the reachable URL
    - logs when IPv4 fallback is selected
  - `TigerRemoteProxyClient` now persists and uses the resolved reachable endpoint
  (`connectedRemoteProxyUrl`) for:
    - STOMP/WebSocket tracing connection
    - REST route/modification operations
  - Added unit test coverage in `AbstractTigerProxyIpv4FallbackTest`:
    - original URL remains first
    - `localhost` expands with `127.0.0.1`
    - IP literals are not expanded

  ## Why

  This addresses connection failures to remote TGR proxy endpoints without requiring JVM-global IPv4
  preference flags in consumers such as Zeta-Testsuite Docker/Maven runs.

  ## Validation

  Executed:
  - `mvn -pl tiger-proxy -Dtest=AbstractTigerProxyIpv4FallbackTest test`

  All targeted tests passed.