### PR TITLE
Use resolved remote Tiger control endpoint

### DIFF
--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/AbstractTigerProxy.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/AbstractTigerProxy.java
@@ -38,6 +38,11 @@ import de.gematik.test.tiger.proxy.exceptions.TigerProxyStartupException;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyPair;
@@ -45,10 +50,12 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import kong.unirest.core.Unirest;
 import lombok.*;
@@ -310,9 +317,22 @@ public abstract class AbstractTigerProxy implements ITigerProxy, AutoCloseable {
     rbelMessageListeners.remove(listener);
   }
 
-  protected void waitForRemoteTigerProxyToBeOnline(String url) {
-    LocalDateTime pollingStart = LocalDateTime.now();
-    while (!isShuttingDown && !isGivenTigerProxyHealthy(url)) {
+  protected String waitForRemoteTigerProxyToBeOnline(String url) {
+    final var candidateUrls = expandUrlWithIpv4Candidates(url);
+    final var pollingStart = LocalDateTime.now();
+    while (!isShuttingDown) {
+      final var reachableCandidate =
+          candidateUrls.stream().filter(this::isGivenTigerProxyHealthy).findFirst();
+      if (reachableCandidate.isPresent()) {
+        final var candidateUrl = reachableCandidate.get();
+        if (!candidateUrl.equals(url)) {
+          log.info(
+              "Remote proxy endpoint '{}' not reachable, using IPv4 fallback '{}'",
+              url,
+              candidateUrl);
+        }
+        return candidateUrl;
+      }
       try {
         Thread.sleep(500);
       } catch (InterruptedException e) {
@@ -328,6 +348,57 @@ public abstract class AbstractTigerProxy implements ITigerProxy, AutoCloseable {
     }
     if (isShuttingDown) {
       log.warn("Aborting waitForRemoteTigerProxyToBeOnline at '{}'", url);
+      return url;
+    }
+    return url;
+  }
+
+  static List<String> expandUrlWithIpv4Candidates(String url) {
+    final var candidateUrls = new LinkedHashSet<String>();
+    candidateUrls.add(url);
+
+    final URI uri;
+    try {
+      uri = URI.create(url);
+    } catch (IllegalArgumentException e) {
+      return List.copyOf(candidateUrls);
+    }
+
+    final var host = uri.getHost();
+    if (StringUtils.isBlank(host) || isIpLiteral(host)) {
+      return List.copyOf(candidateUrls);
+    }
+
+    try {
+      candidateUrls.addAll(
+          List.of(InetAddress.getAllByName(host)).stream()
+              .filter(Inet4Address.class::isInstance)
+              .map(InetAddress::getHostAddress)
+              .map(ipv4Address -> replaceHost(uri, ipv4Address))
+              .collect(Collectors.toCollection(LinkedHashSet::new)));
+    } catch (UnknownHostException e) {
+      return List.copyOf(candidateUrls);
+    }
+    return List.copyOf(candidateUrls);
+  }
+
+  private static boolean isIpLiteral(String host) {
+    return host.contains(":") || host.matches("\\d+\\.\\d+\\.\\d+\\.\\d+");
+  }
+
+  private static String replaceHost(URI uri, String newHost) {
+    try {
+      return new URI(
+              uri.getScheme(),
+              uri.getUserInfo(),
+              newHost,
+              uri.getPort(),
+              uri.getPath(),
+              uri.getQuery(),
+              uri.getFragment())
+          .toString();
+    } catch (URISyntaxException e) {
+      return uri.toString();
     }
   }
 

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClient.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClient.java
@@ -634,12 +634,26 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   private boolean shouldBypassMissingPreviousMessage(
       String previousMessageUuid, Optional<RbelElement> previousMessage) {
-    return !getTigerProxyConfiguration().isDownloadInitialTrafficFromEndpoints()
-        && previousMessage.isEmpty()
-        && !partiallyReceivedMessageMap.containsKey(previousMessageUuid)
-        && !getRbelLogger().getRbelConverter().getKnownMessageUuids().contains(previousMessageUuid)
-        && !removedMessageUuids.contains(previousMessageUuid)
-        && !remoteMessageUuidsSeenSinceConnect.contains(previousMessageUuid);
+    // When we attach to the live mesh without downloading historical traffic first,
+    // the first live message can legitimately point to a predecessor from before our attach.
+    // In that case waiting would only burn the fallback timeout, so we bypass the dependency
+    // check only if the predecessor is unknown across all local tracking structures.
+    boolean liveAttachWithoutInitialHistory =
+        !getTigerProxyConfiguration().isDownloadInitialTrafficFromEndpoints();
+    boolean previousMessageIsUnknownLocally =
+        previousMessage.isEmpty()
+            && !partiallyReceivedMessageMap.containsKey(previousMessageUuid)
+            && !getRbelLogger()
+                .getRbelConverter()
+                .getKnownMessageUuids()
+                .contains(previousMessageUuid)
+            && !removedMessageUuids.contains(previousMessageUuid);
+    boolean previousMessageWasNotSeenInThisLiveSession =
+        !remoteMessageUuidsSeenSinceConnect.contains(previousMessageUuid);
+
+    return liveAttachWithoutInitialHistory
+        && previousMessageIsUnknownLocally
+        && previousMessageWasNotSeenInThisLiveSession;
   }
 
   private void scheduleDirectParsingIfPreviousMessageHasNotEvenPartiallyArrived(

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClient.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClient.java
@@ -81,6 +81,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
   public static final String WS_DATA = "/topic/data";
   public static final String WS_ERRORS = "/topic/errors";
   @Getter private final String remoteProxyUrl;
+  @Getter private String connectedRemoteProxyUrl;
   private final WebSocketStompClient tigerProxyStompClient;
 
   @Getter private final List<TigerExceptionDto> receivedRemoteExceptions = new ArrayList<>();
@@ -124,6 +125,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
       @Nullable TigerProxy masterTigerProxy) {
     super(configuration, masterTigerProxy == null ? null : masterTigerProxy.getRbelLogger());
     this.remoteProxyUrl = remoteProxyUrl;
+    this.connectedRemoteProxyUrl = remoteProxyUrl;
     this.masterTigerProxy = masterTigerProxy;
     this.binaryChunksBuffer =
         new MultipleBinaryConnectionParser(
@@ -185,12 +187,12 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
     if (isShuttingDown()) {
       return;
     }
-    waitForRemoteTigerProxyToBeOnline(remoteProxyUrl);
+    connectedRemoteProxyUrl = waitForRemoteTigerProxyToBeOnline(remoteProxyUrl);
     if (isShuttingDown()) {
       return;
     }
-    log.info("remote proxy at {} is online, now connecting...", remoteProxyUrl);
-    final String tracingWebSocketUrl = getTracingWebSocketUrl(remoteProxyUrl);
+    log.info("remote proxy at {} is online, now connecting...", connectedRemoteProxyUrl);
+    final var tracingWebSocketUrl = getTracingWebSocketUrl(connectedRemoteProxyUrl);
     tigerProxyStompClient
         .connectAsync(tracingWebSocketUrl, tigerStompSessionHandler)
         .orTimeout(connectionTimeoutInSeconds, TimeUnit.SECONDS)
@@ -204,12 +206,13 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
                   () -> {
                     log.info(
                         "Connected to remote proxy at {}, now downloading traffic...",
-                        remoteProxyUrl);
+                        connectedRemoteProxyUrl);
                     if (downloadTraffic) {
                       downloadTrafficFromRemoteProxy();
                     }
                     log.info(
-                        "Successfully downloaded traffic from remote proxy at {}", remoteProxyUrl);
+                        "Successfully downloaded traffic from remote proxy at {}",
+                        connectedRemoteProxyUrl);
                   });
               return stompSessionInCallback;
             })
@@ -224,7 +227,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public TigerProxyRoute addRoute(TigerProxyRoute tigerRoute) {
-    return Unirest.put(remoteProxyUrl + "/route")
+    return Unirest.put(getBaseUrl() + "/route")
         .body(tigerRoute)
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .asObject(TigerProxyRoute.class)
@@ -243,8 +246,8 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
   public void removeRoute(String routeId) {
     Assert.hasText(routeId, () -> "No route ID given!");
 
-    final Optional<Boolean> isInternalOptional =
-        Unirest.get(remoteProxyUrl + "/route")
+    final var isInternalOptional =
+        Unirest.get(getBaseUrl() + "/route")
             .asObject(new GenericType<List<TigerProxyRoute>>() {})
             .getBody()
             .stream()
@@ -260,7 +263,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
           "Could not delete route with id '" + routeId + "': Is internal route!");
     }
 
-    Unirest.delete(remoteProxyUrl + "/route/" + routeId)
+    Unirest.delete(getBaseUrl() + "/route/" + routeId)
         .asString()
         .ifFailure(
             httpResponse -> {
@@ -271,7 +274,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public void clearAllRoutes() {
-    Unirest.get(remoteProxyUrl + "/route")
+    Unirest.get(getBaseUrl() + "/route")
         .asObject(new GenericType<List<TigerProxyRoute>>() {})
         .getBody()
         .stream()
@@ -282,7 +285,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public String getBaseUrl() {
-    return remoteProxyUrl;
+    return connectedRemoteProxyUrl;
   }
 
   @Override
@@ -292,7 +295,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public List<TigerProxyRoute> getRoutes() {
-    return Unirest.get(remoteProxyUrl + "/route")
+    return Unirest.get(getBaseUrl() + "/route")
         .asObject(new GenericType<List<TigerProxyRoute>>() {})
         .ifFailure(
             response -> {
@@ -307,7 +310,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public RbelModificationDescription addModificaton(RbelModificationDescription modification) {
-    return Unirest.put(remoteProxyUrl + "/modification")
+    return Unirest.put(getBaseUrl() + "/modification")
         .body(modification)
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .asObject(RbelModificationDescription.class)
@@ -324,7 +327,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
 
   @Override
   public List<RbelModificationDescription> getModifications() {
-    return Unirest.get(remoteProxyUrl + "/modification")
+    return Unirest.get(getBaseUrl() + "/modification")
         .asObject(new GenericType<List<RbelModificationDescription>>() {})
         .ifFailure(
             response -> {
@@ -340,7 +343,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
   @Override
   public void removeModification(String modificationName) {
     Assert.hasText(modificationName, () -> "No modification name given!");
-    Unirest.delete(remoteProxyUrl + "/modification/" + modificationName)
+    Unirest.delete(getBaseUrl() + "/modification/" + modificationName)
         .asEmpty()
         .ifFailure(
             httpResponse -> {

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClient.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClient.java
@@ -46,6 +46,10 @@ import de.gematik.test.tiger.proxy.handler.MultipleBinaryConnectionParser;
 import de.gematik.test.tiger.proxy.handler.SingleConnectionParser;
 import jakarta.websocket.ContainerProvider;
 import jakarta.websocket.WebSocketContainer;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -82,6 +86,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
   public static final String WS_ERRORS = "/topic/errors";
   @Getter private final String remoteProxyUrl;
   @Getter private String connectedRemoteProxyUrl;
+  private final String remoteProxyControlUrl;
   private final WebSocketStompClient tigerProxyStompClient;
 
   @Getter private final List<TigerExceptionDto> receivedRemoteExceptions = new ArrayList<>();
@@ -125,7 +130,8 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
       @Nullable TigerProxy masterTigerProxy) {
     super(configuration, masterTigerProxy == null ? null : masterTigerProxy.getRbelLogger());
     this.remoteProxyUrl = remoteProxyUrl;
-    this.connectedRemoteProxyUrl = remoteProxyUrl;
+    this.remoteProxyControlUrl = normalizeLoopbackRemoteProxyUrl(remoteProxyUrl);
+    this.connectedRemoteProxyUrl = this.remoteProxyControlUrl;
     this.masterTigerProxy = masterTigerProxy;
     this.binaryChunksBuffer =
         new MultipleBinaryConnectionParser(
@@ -176,6 +182,36 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
     return remoteProxyUrl.replaceFirst("http", "ws") + "/tracing";
   }
 
+  static String normalizeLoopbackRemoteProxyUrl(String remoteProxyUrl) {
+    try {
+      URI uri = new URI(remoteProxyUrl);
+      if (uri.getHost() == null) {
+        return remoteProxyUrl;
+      }
+
+      InetAddress inetAddress = InetAddress.getByName(uri.getHost());
+      if (!inetAddress.isLoopbackAddress() || "localhost".equalsIgnoreCase(uri.getHost())) {
+        return remoteProxyUrl;
+      }
+
+      return new URI(
+              uri.getScheme(),
+              uri.getUserInfo(),
+              "localhost",
+              uri.getPort(),
+              uri.getPath(),
+              uri.getQuery(),
+              uri.getFragment())
+          .toString();
+    } catch (URISyntaxException | UnknownHostException e) {
+      return remoteProxyUrl;
+    }
+  }
+
+  String getRemoteProxyControlUrl() {
+    return remoteProxyControlUrl;
+  }
+
   private void downloadTrafficFromRemoteProxy() {
     new TigerRemoteTrafficDownloader(this).execute();
   }
@@ -187,7 +223,7 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
     if (isShuttingDown()) {
       return;
     }
-    connectedRemoteProxyUrl = waitForRemoteTigerProxyToBeOnline(remoteProxyUrl);
+    connectedRemoteProxyUrl = waitForRemoteTigerProxyToBeOnline(remoteProxyControlUrl);
     if (isShuttingDown()) {
       return;
     }
@@ -519,6 +555,8 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
    * the buffer is full.
    */
   private final RingBufferHashSet<String> removedMessageUuids = new RingBufferHashSet<>(10_000);
+  private final RingBufferHashSet<String> remoteMessageUuidsSeenSinceConnect =
+      new RingBufferHashSet<>(10_000);
 
   private void handleMessageRemovalFromHistory(RbelElement element) {
     if (!element.hasFacet(NextMessageParsedFacet.class)) {
@@ -530,12 +568,15 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
     synchronized (parsingTasksWaitingForUuid) {
       parsingTasksWaitingForUuid.clear();
       removedMessageUuids.clear();
+      remoteMessageUuidsSeenSinceConnect.clear();
     }
   }
 
   public void scheduleAfterMessage(
       String previousMessageUuid, Runnable parseMessageTask, String thisMessageUuid) {
     synchronized (parsingTasksWaitingForUuid) {
+      remoteMessageUuidsSeenSinceConnect.add(thisMessageUuid);
+
       if (removedMessageUuids.contains(previousMessageUuid)) {
         log.trace(
             "parsing {} immediately, prev {} is already finished and removed",
@@ -545,10 +586,20 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
         removedMessageUuids.remove(previousMessageUuid);
         return;
       }
+
       Optional<RbelElement> previousMessage =
           getRbelLogger().getRbelConverter().findMessageByUuid(previousMessageUuid);
       final Optional<RbelConversionPhase> previousMessageConversionPhase =
           previousMessage.map(RbelElement::getConversionPhase);
+
+      if (shouldBypassMissingPreviousMessage(previousMessageUuid, previousMessage)) {
+        log.debug(
+            "Parsing {} immediately, prev {} belongs to traffic before the live mesh attach",
+            thisMessageUuid,
+            previousMessageUuid);
+        meshHandlerPool.submit(parseMessageTask);
+        return;
+      }
 
       if (previousMessageConversionPhase.map(RbelConversionPhase::isFinished).orElse(false)) {
         log.trace(
@@ -579,6 +630,16 @@ public class TigerRemoteProxyClient extends AbstractTigerProxy implements AutoCl
             thisMessageUuid, previousMessageUuid, parseMessageTask);
       }
     }
+  }
+
+  private boolean shouldBypassMissingPreviousMessage(
+      String previousMessageUuid, Optional<RbelElement> previousMessage) {
+    return !getTigerProxyConfiguration().isDownloadInitialTrafficFromEndpoints()
+        && previousMessage.isEmpty()
+        && !partiallyReceivedMessageMap.containsKey(previousMessageUuid)
+        && !getRbelLogger().getRbelConverter().getKnownMessageUuids().contains(previousMessageUuid)
+        && !removedMessageUuids.contains(previousMessageUuid)
+        && !remoteMessageUuidsSeenSinceConnect.contains(previousMessageUuid);
   }
 
   private void scheduleDirectParsingIfPreviousMessageHasNotEvenPartiallyArrived(

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/client/TigerRemoteTrafficDownloader.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/client/TigerRemoteTrafficDownloader.java
@@ -218,7 +218,7 @@ public class TigerRemoteTrafficDownloader {
   }
 
   private String getRemoteProxyUrl() {
-    return tigerRemoteProxyClient.getRemoteProxyUrl();
+    return tigerRemoteProxyClient.getBaseUrl();
   }
 
   @Data

--- a/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/AbstractTigerProxyIpv4FallbackTest.java
+++ b/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/AbstractTigerProxyIpv4FallbackTest.java
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright 2021-2025 gematik GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * *******
+ *
+ * For additional notes and disclaimer from gematik and in case of changes by gematik find details in the "Readme" file.
+ */
+package de.gematik.test.tiger.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AbstractTigerProxyIpv4FallbackTest {
+
+  @Test
+  void expandUrlWithIpv4Candidates_shouldKeepOriginalUrlFirst() {
+    List<String> candidates =
+        AbstractTigerProxy.expandUrlWithIpv4Candidates("http://localhost:8080/tracing");
+
+    assertThat(candidates).isNotEmpty();
+    assertThat(candidates.get(0)).isEqualTo("http://localhost:8080/tracing");
+  }
+
+  @Test
+  void expandUrlWithIpv4Candidates_shouldAddIpv4VariantForLocalhost() {
+    List<String> candidates =
+        AbstractTigerProxy.expandUrlWithIpv4Candidates("http://localhost:8080/tracing");
+
+    assertThat(candidates).contains("http://127.0.0.1:8080/tracing");
+  }
+
+  @Test
+  void expandUrlWithIpv4Candidates_shouldNotExpandIpLiterals() {
+    assertThat(AbstractTigerProxy.expandUrlWithIpv4Candidates("http://127.0.0.1:8080/tracing"))
+        .containsExactly("http://127.0.0.1:8080/tracing");
+
+    assertThat(AbstractTigerProxy.expandUrlWithIpv4Candidates("http://[::1]:8080/tracing"))
+        .containsExactly("http://[::1]:8080/tracing");
+  }
+}

--- a/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClientSchedulingAdditionalTest.java
+++ b/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClientSchedulingAdditionalTest.java
@@ -53,8 +53,13 @@ class TigerRemoteProxyClientSchedulingAdditionalTest {
   }
 
   private TigerRemoteProxyClient newClient(int timeoutMs) {
+    return newClient(timeoutMs, false);
+  }
+
+  private TigerRemoteProxyClient newClient(int timeoutMs, boolean downloadInitialTraffic) {
     TigerProxyConfiguration cfg =
         TigerProxyConfiguration.builder()
+            .downloadInitialTrafficFromEndpoints(downloadInitialTraffic)
             .waitForPreviousMessageBeforeParsingInSeconds((float) (timeoutMs / 1000.0))
             .proxyLogLevel("WARN")
             .build();
@@ -151,6 +156,46 @@ class TigerRemoteProxyClientSchedulingAdditionalTest {
         (RingBufferHashMap<String, List<Runnable>>)
             ReflectionTestUtils.getField(client, "parsingTasksWaitingForUuid");
     assertThat(waiting.get(prevUuid)).as("Waiting entry for prev should be cleared").isEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "Missing historical previous is bypassed immediately when initial traffic download is disabled")
+  void scheduleAfterMessage_missingHistoricalPrevious_executesImmediatelyWithoutInitialDownload()
+      throws Exception {
+    client = newClient(500, false);
+
+    CountDownLatch latch = new CountDownLatch(1);
+
+    client.scheduleAfterMessage("historical-prev-uuid", latch::countDown, "first-live-uuid");
+
+    assertThat(latch.await(150, TimeUnit.MILLISECONDS))
+        .as("First live message should not wait for traffic that predates the subscription")
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName(
+      "Subsequent live message still waits for the immediately preceding live message to finish")
+  void scheduleAfterMessage_followUpLiveMessageStillWaitsForPreviousLiveMessage() throws Exception {
+    client = newClient(500, false);
+
+    CountDownLatch firstLatch = new CountDownLatch(1);
+    client.scheduleAfterMessage("historical-prev-uuid", firstLatch::countDown, "first-live-uuid");
+    assertThat(firstLatch.await(150, TimeUnit.MILLISECONDS)).isTrue();
+
+    CountDownLatch secondLatch = new CountDownLatch(1);
+    client.scheduleAfterMessage("first-live-uuid", secondLatch::countDown, "second-live-uuid");
+
+    assertThat(secondLatch.getCount())
+        .as("Second live message should stay queued behind the first one")
+        .isEqualTo(1);
+
+    @SuppressWarnings("unchecked")
+    RingBufferHashMap<String, List<Runnable>> waiting =
+        (RingBufferHashMap<String, List<Runnable>>)
+            ReflectionTestUtils.getField(client, "parsingTasksWaitingForUuid");
+    assertThat(waiting.get("first-live-uuid")).isNotEmpty();
   }
 
   @Test

--- a/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClientTest.java
+++ b/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/client/TigerRemoteProxyClientTest.java
@@ -243,6 +243,18 @@ class TigerRemoteProxyClientTest {
   }
 
   @Test
+  void shouldNormalizeLoopbackControlUrlsToLocalhost() {
+    assertThat(TigerRemoteProxyClient.normalizeLoopbackRemoteProxyUrl("http://127.0.0.2:9999"))
+        .isEqualTo("http://localhost:9999");
+    assertThat(TigerRemoteProxyClient.normalizeLoopbackRemoteProxyUrl("http://localhost:9999"))
+        .isEqualTo("http://localhost:9999");
+    assertThat(
+            TigerRemoteProxyClient.normalizeLoopbackRemoteProxyUrl(
+                "http://example.invalid:9999"))
+        .isEqualTo("http://example.invalid:9999");
+  }
+
+  @Test
   void sendMessage_shouldTriggerListener() {
     AtomicInteger listenerCallCounter = new AtomicInteger(0);
     tigerRemoteProxyClient.addRbelMessageListener(msg -> listenerCallCounter.incrementAndGet());


### PR DESCRIPTION
## Summary

This PR fixes the remote Tiger proxy control path to use the actually reachable endpoint instead of relying on the originally configured hostname  everywhere.

## Problem

Remote Tiger proxy access can fail when the configured hostname is not the endpoint that is actually reachable from the runtime environment.

## Changes

  - keep the existing loopback alias handling for local setups
  - make `waitForRemoteTigerProxyToBeOnline(...)` return the reachable candidate URL
  - expand remote hostnames to IPv4 candidates during endpoint probing
  - store the reachable endpoint as `connectedRemoteProxyUrl`
  - use the resolved endpoint consistently for:
    - websocket/STOMP connect
    - remote traffic download
    - remote route operations
    - remote modification operations
  - keep the live-mesh scheduling fix and its tests

## Validation

Validated in `tiger-proxy` with:

`mvn -pl tiger-proxy -Dtest=TigerRemoteProxyClientSchedulingAdditionalTest,TigerRemoteProxyClientTest#shouldNormalizeLoopbackControlUrlsToLocalhost test`