### PR TITLE
fix: enforce light color-scheme to prevent dark mode contrast issues

### DIFF
--- a/tiger-testenv-mgr/src/frontend/index.html
+++ b/tiger-testenv-mgr/src/frontend/index.html
@@ -21,7 +21,7 @@
 
 -->
 <!DOCTYPE html>
-<html lang="">
+<html lang="" style="color-scheme: light;">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/tiger-testenv-mgr/src/frontend/public/css/bootstrap-tiger.css
+++ b/tiger-testenv-mgr/src/frontend/public/css/bootstrap-tiger.css
@@ -77,6 +77,7 @@
     --bs-body-line-height: 1.5;
     --bs-body-color: #212529;
     --bs-body-bg: #fff;
+    color-scheme: light;
 }
 
 *,

--- a/tiger-testenv-mgr/src/frontend/src/App.vue
+++ b/tiger-testenv-mgr/src/frontend/src/App.vue
@@ -126,6 +126,6 @@ i.fa-solid.right {
 .smallcode {
   font-size: 60%;
   font-family: courier, monospace;
-  color: darkgray;
+  color: #6c757d;
 }
 </style>

--- a/tiger-testenv-mgr/src/frontend/src/components/testsuite/ExecutionPane.vue
+++ b/tiger-testenv-mgr/src/frontend/src/components/testsuite/ExecutionPane.vue
@@ -365,6 +365,7 @@ h4.scenariotitle {
 .step_text {
   font-size: 80%;
   width: 99%;
+  color: var(--bs-body-color, #212529);
 }
 
 .rbelDetailsBadge {

--- a/tiger-testenv-mgr/src/frontend/src/pages/TestProject.vue
+++ b/tiger-testenv-mgr/src/frontend/src/pages/TestProject.vue
@@ -982,6 +982,7 @@ function setReasonWithoutReplacing(reason: QuitReason) {
 
 .steps-docstring {
   color: #0a8694;
+  background-color: var(--bs-body-bg, #fff);
   font-family: Courier, monospace;
   padding-left: 1rem;
   white-space: pre;


### PR DESCRIPTION
## Summary
- On macOS Safari with system dark mode, the Workflow UI is nearly unreadable: the browser inverts the background to black but text colors remain dark, resulting in extremely low contrast on step descriptions
- Set `color-scheme: light` on `<html>` and `:root` to prevent automatic dark mode inversion
- Add explicit text/background colors on `.step_text`, `.steps-docstring`, `.smallcode`

## Screenshot (before)
The step descriptions ("Given ...", "And ...") are barely visible — gray text on dark background:

*(See linked issue for screenshot)*

## Changes
| File | Change |
|------|--------|
| `index.html` | `color-scheme: light` on `<html>` |
| `bootstrap-tiger.css` | `color-scheme: light` in `:root` |
| `ExecutionPane.vue` | Explicit `color` on `.step_text` |
| `TestProject.vue` | Explicit `background-color` on `.steps-docstring` |
| `App.vue` | Replace `darkgray` with `#6c757d` for `.smallcode` |

This does not add full dark mode support — it prevents the broken half-inverted state that makes the UI unusable in dark mode on Safari.

## Test plan
- [ ] Open Workflow UI in Safari with macOS dark mode enabled
- [ ] Verify all step descriptions are readable
- [ ] Verify no visual regressions in light mode