### PR TITLE
Avoid fixed ports in Tiger Proxy tests

### DIFF
--- a/tiger-testenv-mgr/src/test/resources/de/gematik/test/tiger/testenvmgr/testTigerProxy.yaml
+++ b/tiger-testenv-mgr/src/test/resources/de/gematik/test/tiger/testenvmgr/testTigerProxy.yaml
@@ -2,5 +2,5 @@ servers:
   testTigerProxy:
     type: tigerProxy
     tigerProxyConfiguration:
-      adminPort: 9999
-      proxyPort: 10020
+      adminPort: ${free.port.0}
+      proxyPort: ${free.port.1}


### PR DESCRIPTION
Use dynamically allocated free ports for the Tiger Proxy admin and proxy listeners instead of hard-coded values. This prevents collisions when tests run in parallel or on machines where the default ports are already in use.