### PR TITLE
Fix CONNECT tunnel handling and header forwarding

### DIFF
--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/mockserver/netty/proxy/connect/HttpConnectHandler.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/mockserver/netty/proxy/connect/HttpConnectHandler.java
@@ -23,6 +23,7 @@ package de.gematik.test.tiger.mockserver.netty.proxy.connect;
 import static de.gematik.test.tiger.mockserver.model.HttpProtocol.HTTP_1_1;
 import static de.gematik.test.tiger.mockserver.model.HttpProtocol.HTTP_2;
 import static de.gematik.test.tiger.mockserver.model.HttpResponse.response;
+import static de.gematik.test.tiger.mockserver.netty.unification.PortUnificationHandler.disableSslUpstreamAndDownstream;
 import static de.gematik.test.tiger.mockserver.netty.unification.PortUnificationHandler.isSslEnabledDownstream;
 import static de.gematik.test.tiger.mockserver.netty.unification.PortUnificationHandler.isSslEnabledUpstream;
 import static de.gematik.test.tiger.mockserver.socket.tls.SniHandler.PREFERRED_UPSTREAM_KEY_ALGORITHM;
@@ -217,6 +218,10 @@ public final class HttpConnectHandler extends RelayConnectHandler<HttpRequest> {
     removeHandler(pipeline, HttpContentLengthRemover.class);
     removeHandler(pipeline, MessagePostProcessorAdapter.class);
     removeHandler(pipeline, HttpConnectHandler.class);
+
+    // A local CONNECT tunnel may carry either plain HTTP/WebSocket or TLS. Reset the optimistic
+    // CONNECT defaults so protocol detection is driven by the first bytes after 200 Established.
+    disableSslUpstreamAndDownstream(ctx.channel());
 
     pipeline.addLast(
         new PortUnificationHandler(

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/mockserver/netty/unification/PortUnificationHandler.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/mockserver/netty/unification/PortUnificationHandler.java
@@ -210,6 +210,18 @@ public class PortUnificationHandler extends ReplayingDecoder<Void> {
     channel.attr(TLS_ENABLED_DOWNSTREAM).set(Boolean.TRUE);
   }
 
+  public static void disableSslUpstreamAndDownstream(Channel channel) {
+    channel.attr(TLS_ENABLED_UPSTREAM).set(Boolean.FALSE);
+    channel.attr(TLS_ENABLED_DOWNSTREAM).set(Boolean.FALSE);
+    channel.attr(SniHandler.UPSTREAM_SSL_ENGINE).set(null);
+    channel.attr(SniHandler.UPSTREAM_SSL_HANDLER).set(null);
+    channel.attr(SniHandler.UPSTREAM_CLIENT_CERTIFICATES).set(null);
+    channel.attr(SniHandler.SSL_SESSION).set(null);
+    channel.attr(SniHandler.NEGOTIATED_APPLICATION_PROTOCOL).set(null);
+    channel.attr(SniHandler.SERVER_IDENTITY).set(null);
+    channel.attr(SniHandler.PREFERRED_UPSTREAM_KEY_ALGORITHM).set(null);
+  }
+
   public static boolean isSslEnabledUpstream(Channel channel) {
     if (channel.attr(TLS_ENABLED_UPSTREAM).get() != null) {
       return channel.attr(TLS_ENABLED_UPSTREAM).get();


### PR DESCRIPTION
Reset optimistic TLS defaults after local CONNECT establishment so protocol detection is based on the actual tunnel payload. Preserve Accept-Encoding, defer hostname resolution, and retain duplicate multimap entries.