### PR TITLE
Add proxy-scoped JWT manipulation support

### DIFF
--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/TigerProxy.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/TigerProxy.java
@@ -33,17 +33,20 @@ import de.gematik.test.tiger.common.data.config.tigerproxy.TigerProxyConfigurati
 import de.gematik.test.tiger.common.data.config.tigerproxy.TigerTlsConfiguration;
 import de.gematik.test.tiger.common.pki.TigerPkiIdentity;
 import de.gematik.test.tiger.mockserver.configuration.MockServerConfiguration;
+import de.gematik.test.tiger.mockserver.model.HttpRequest;
 import de.gematik.test.tiger.mockserver.mock.Expectation;
 import de.gematik.test.tiger.mockserver.netty.MockServer;
 import de.gematik.test.tiger.mockserver.proxyconfiguration.ProxyConfiguration;
 import de.gematik.test.tiger.mockserver.socket.tls.KeyAndCertificateFactory;
 import de.gematik.test.tiger.proxy.client.TigerRemoteProxyClient;
 import de.gematik.test.tiger.proxy.configuration.ProxyConfigurationConverter;
+import de.gematik.test.tiger.proxy.data.JwtManipulationConfiguration;
 import de.gematik.test.tiger.proxy.data.TigerConnectionStatus;
 import de.gematik.test.tiger.proxy.data.TigerProxyRoute;
 import de.gematik.test.tiger.proxy.exceptions.TigerProxyStartupException;
 import de.gematik.test.tiger.proxy.handler.BinaryExchangeHandler;
 import de.gematik.test.tiger.proxy.handler.ForwardAllCallback;
+import de.gematik.test.tiger.proxy.handler.JwtManipulationCallback;
 import de.gematik.test.tiger.proxy.handler.RbelBinaryModifierPlugin;
 import de.gematik.test.tiger.proxy.tls.DynamicKeyAndCertificateFactory;
 import de.gematik.test.tiger.proxy.tls.MockServerTlsConfigurator;
@@ -65,6 +68,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
+import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -82,6 +86,9 @@ public class TigerProxy extends AbstractTigerProxy implements AutoCloseable, Rbe
   @Getter private final MockServerToRbelConverter mockServerToRbelConverter;
   private final Map<String, TigerProxyRoute> tigerRouteMap = new HashMap<>();
   private final List<TigerRemoteProxyClient> remoteProxyClients = new ArrayList<>();
+  private final Object jwtManipulationStateMonitor = new Object();
+  @Nullable private JwtManipulationConfiguration jwtManipulationConfiguration;
+  private int jwtManipulationExecutionCount = 0;
 
   /**
    * Tiger Proxy health endpoint performs http get requests towards the local server port of the
@@ -338,6 +345,72 @@ public class TigerProxy extends AbstractTigerProxy implements AutoCloseable, Rbe
   @Override
   public List<RbelModificationDescription> getModifications() {
     return getRbelLogger().getRbelModifier().getModifications();
+  }
+
+  /**
+   * Stores the active JWT manipulation on this proxy instance and resets the execution counter
+   * used for {@code deleteAfterNExecutions}.
+   */
+  public void configureJwtManipulation(JwtManipulationConfiguration configuration) {
+    synchronized (jwtManipulationStateMonitor) {
+      jwtManipulationConfiguration = configuration;
+      jwtManipulationExecutionCount = 0;
+    }
+  }
+
+  /** Clears the active JWT manipulation and its execution counter. */
+  public void clearJwtManipulation() {
+    synchronized (jwtManipulationStateMonitor) {
+      jwtManipulationConfiguration = null;
+      jwtManipulationExecutionCount = 0;
+    }
+  }
+
+  /** Clears both JWT manipulation state and classic RBEL modifications. */
+  public void clearAllManipulations() {
+    clearJwtManipulation();
+    getRbelLogger().getRbelModifier().deleteAllModifications();
+  }
+
+  /** Returns the currently configured proxy-scoped JWT manipulation, if any. */
+  public Optional<JwtManipulationConfiguration> getJwtManipulationConfiguration() {
+    synchronized (jwtManipulationStateMonitor) {
+      return Optional.ofNullable(jwtManipulationConfiguration);
+    }
+  }
+
+  /** Returns whether a JWT manipulation is currently active on this proxy instance. */
+  public boolean hasActiveJwtManipulation() {
+    synchronized (jwtManipulationStateMonitor) {
+      return jwtManipulationConfiguration != null;
+    }
+  }
+
+  /**
+   * Records one execution of the active JWT manipulation and clears it when the configured limit
+   * is reached.
+   *
+   * @return {@code true} when the manipulation was cleared after reaching its execution limit
+   */
+  public boolean recordJwtManipulationExecutionAndClearIfNeeded() {
+    synchronized (jwtManipulationStateMonitor) {
+      if (jwtManipulationConfiguration == null
+          || jwtManipulationConfiguration.getDeleteAfterNExecutions() == null) {
+        return false;
+      }
+      jwtManipulationExecutionCount++;
+      if (jwtManipulationExecutionCount >= jwtManipulationConfiguration.getDeleteAfterNExecutions()) {
+        jwtManipulationConfiguration = null;
+        jwtManipulationExecutionCount = 0;
+        return true;
+      }
+      return false;
+    }
+  }
+
+  /** Applies the currently configured JWT manipulation to the given request, if one is active. */
+  public void applyJwtManipulationIfConfigured(HttpRequest request) {
+    JwtManipulationCallback.applyJwtManipulationIfConfigured(this, request);
   }
 
   @Override

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/controller/ManipulationController.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/controller/ManipulationController.java
@@ -1,0 +1,187 @@
+/*
+ *
+ * Copyright 2021-2025 gematik GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * *******
+ *
+ * For additional notes and disclaimer from gematik and in case of changes by gematik find details in the "Readme" file.
+ */
+package de.gematik.test.tiger.proxy.controller;
+
+import de.gematik.test.tiger.common.config.RbelModificationDescription;
+import de.gematik.test.tiger.proxy.TigerProxy;
+import de.gematik.test.tiger.proxy.controller.dto.JwtManipulationRequest;
+import de.gematik.test.tiger.proxy.data.JwtManipulationConfiguration;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@Data
+@RequiredArgsConstructor
+@Validated
+@RestController
+@Slf4j
+@RequestMapping("/manipulation")
+public class ManipulationController {
+  private final TigerProxy tigerProxy;
+
+  @PostMapping(value = "/modifyJwt", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> modifyJwt(@RequestBody JwtManipulationRequest request) {
+    // Validate required fields
+    if (StringUtils.isBlank(request.getJwtLocation())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jwtLocation must not be empty");
+    }
+    if (StringUtils.isBlank(request.getJwtField())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jwtField must not be empty");
+    }
+    if (request.getReplaceWith() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "replaceWith must not be null");
+    }
+
+    // Keep JWT manipulation state on the proxy instance so concurrent proxies do not share static
+    // callback state or execution counters.
+    tigerProxy.configureJwtManipulation(
+        JwtManipulationConfiguration.builder()
+            .name(request.getName())
+            .condition(request.getCondition())
+            .jwtLocation(request.getJwtLocation())
+            .jwtField(request.getJwtField())
+            .replaceWith(request.getReplaceWith())
+            .privateKeyPem(request.getPrivateKeyPem())
+            .deleteAfterNExecutions(request.getDeleteAfterNExecutions())
+            .replaceJwk(request.getReplaceJwk())
+            .dpopLocation(request.getDpopLocation())
+            .dpopPrivateKeyPem(request.getDpopPrivateKeyPem())
+            .updateAth(request.getUpdateAth())
+            .build());
+
+    log.info("JWT manipulation configured: {} {} -> {}", request.getJwtLocation(), request.getJwtField(), request.getReplaceWith());
+
+    String response = "JWT manipulation applied: " + request.getJwtLocation() + " " + request.getJwtField();
+    if (StringUtils.isNotBlank(request.getPrivateKeyPem())) {
+      response += " (with re-signing)";
+    } else {
+      response += " (no re-signing)";
+    }
+
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * Revert all JWT manipulations.
+   *
+   * @return ok if the manipulations were removed
+   */
+  @PostMapping(value = "/resetJwtManipulation")
+  public ResponseEntity<String> resetManipulation() {
+    // Reset only the JWT-specific state. RBEL modifications can be inspected or cleared
+    // independently via the dedicated manipulation endpoints.
+    tigerProxy.clearJwtManipulation();
+    return ResponseEntity.ok("JWT manipulation deactivated");
+  }
+
+  /**
+   * Get active JWT manipulations.
+   *
+   * @return active manipulation as string
+   */
+  @GetMapping(value = "/getJwtManipulation")
+  public ResponseEntity<String> getManipulation() {
+    var activeManipulations = new ArrayList<String>();
+    tigerProxy
+        .getJwtManipulationConfiguration()
+        .ifPresent(
+            configuration ->
+                activeManipulations.add(
+                    "Active JWT manipulation: "
+                        + configuration.getJwtLocation()
+                        + " "
+                        + configuration.getJwtField()
+                        + " = "
+                        + configuration.getReplaceWith()));
+    var modifications = tigerProxy.getModifications();
+    if (!modifications.isEmpty()) {
+      activeManipulations.add("Active RBel modifications: " + modifications.size());
+    }
+
+    if (activeManipulations.isEmpty()) {
+      return ResponseEntity.ok("No active manipulation");
+    }
+    return ResponseEntity.ok(String.join("; ", activeManipulations));
+  }
+
+  /**
+   * Delete of all existing manipulations.
+   *
+   * @return Ok with everything worked correctly
+   */
+  @DeleteMapping(value = "/modification")
+  public ResponseEntity<String> deleteAllModification() {
+    // This endpoint mirrors the previous "reset everything" behavior for callers that expect both
+    // JWT manipulation and classic RBEL modifications to be cleared together.
+    tigerProxy.clearAllManipulations();
+    return ResponseEntity.ok("All manipulation are deactivated");
+  }
+
+  /**
+   * Add a key-file to tigerproxy for resign after manipulation.
+   * Accepts JSON with algorithm and base64-encoded key.
+   * Request format:
+   * {
+   *   "algorithm": "EC",
+   *   "keyBase64": "MIGTAgEAMBMGByqGSM..."
+   * }
+   *
+   * @param name Name of the key, needed for TigerProxy to find the right key for a manipulation.
+   */
+  @PutMapping(value = "/key/{name}", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public void addKey(
+      @PathVariable("name") String name,
+      @RequestBody KeyRequest request
+  ) throws Exception {
+    // Clean base64 input
+    String sanitizedKey = request.keyBase64().replaceAll("[\\r\\n\\s]+", "");
+
+    // Decode Base64 to DER bytes
+    byte[] keyBytes = Base64.getDecoder().decode(sanitizedKey);
+
+    // Create PrivateKey with specified algorithm
+    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+    KeyFactory keyFactory = KeyFactory.getInstance(request.algorithm());
+    PrivateKey privateKey = keyFactory.generatePrivate(keySpec);
+
+    tigerProxy.addKey(name, privateKey);
+  }
+
+  /**
+   * JSON Request DTO with algorithm and base64 key
+   */
+  public record KeyRequest(String algorithm, String keyBase64) {}
+
+}

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/controller/dto/JwtManipulationRequest.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/controller/dto/JwtManipulationRequest.java
@@ -1,0 +1,50 @@
+/*
+ *
+ * Copyright 2021-2025 gematik GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * *******
+ *
+ * For additional notes and disclaimer from gematik and in case of changes by gematik find details in the "Readme" file.
+ */
+package de.gematik.test.tiger.proxy.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JwtManipulationRequest {
+
+  private String name;
+  private String condition;
+
+  // New approach: separate location and field
+  private String jwtLocation;  // e.g., "$.header.dpop", "$.body.client_assertion", "$.body.subject_token"
+  private String jwtField;     // e.g., "header.typ", "body.iss", "body.sub"
+
+  private String replaceWith;
+  private String privateKeyPem;
+  private Integer deleteAfterNExecutions;
+  private Boolean replaceJwk;  // Replace JWK with public key derived from privateKeyPem
+
+  // DPoP ath update: when manipulating access token, also update ath in DPoP
+  private String dpopLocation;      // e.g., "$.header.dpop" - where the DPoP JWT is located
+  private String dpopPrivateKeyPem; // Private key to re-sign the DPoP JWT
+  private Boolean updateAth;        // If true, recalculate ath from manipulated access token
+}

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/data/JwtManipulationConfiguration.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/data/JwtManipulationConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ *
+ * Copyright 2021-2025 gematik GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * *******
+ *
+ * For additional notes and disclaimer from gematik and in case of changes by gematik find details in the "Readme" file.
+ */
+package de.gematik.test.tiger.proxy.data;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Immutable proxy-scoped configuration for a JWT manipulation request, including optional
+ * re-signing and DPoP {@code ath} update settings.
+ */
+@Value
+@Builder(toBuilder = true)
+public class JwtManipulationConfiguration {
+  String name;
+  String condition;
+  String jwtLocation;
+  String jwtField;
+  String replaceWith;
+  String privateKeyPem;
+  Integer deleteAfterNExecutions;
+  Boolean replaceJwk;
+  String dpopLocation;
+  String dpopPrivateKeyPem;
+  Boolean updateAth;
+}

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/handler/ForwardProxyCallback.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/handler/ForwardProxyCallback.java
@@ -42,6 +42,7 @@ public class ForwardProxyCallback extends AbstractRouteProxyCallback {
   @Override
   @SuppressWarnings("java:S1075")
   public HttpRequest handleRequest(HttpRequest req) {
+    getTigerProxy().applyJwtManipulationIfConfigured(req);
     applyModifications(req);
     if (!getTigerRoute().isPreserveHostHeader()) {
       req.replaceHeader(header("Host", getTargetUrl().getHost() + ":" + getPort()));

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/handler/JwtManipulationCallback.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/handler/JwtManipulationCallback.java
@@ -1,0 +1,1003 @@
+/*
+ *
+ * Copyright 2021-2025 gematik GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * *******
+ *
+ * For additional notes and disclaimer from gematik and in case of changes by gematik find details in the "Readme" file.
+ */
+package de.gematik.test.tiger.proxy.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import de.gematik.test.tiger.mockserver.model.HttpRequest;
+import de.gematik.test.tiger.proxy.TigerProxy;
+import de.gematik.test.tiger.proxy.data.JwtManipulationConfiguration;
+import java.io.StringReader;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.jose4j.jwk.EllipticCurveJsonWebKey;
+import org.jose4j.jwk.JsonWebKey;
+import org.jose4j.jws.EcdsaUsingShaAlgorithm;
+
+/**
+ * Utility for request-scoped JWT manipulation using proxy-scoped configuration.
+ *
+ * <p>The configuration separates where the JWT is located, for example
+ * {@code $.header.dpop} or {@code $.body.client_assertion}, from what should change inside the
+ * JWT, for example {@code header.typ}, {@code body.iss}, or {@code body.aud.0}.
+ */
+@Slf4j
+public final class JwtManipulationCallback {
+
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final Pattern JWT_HEADER_PREFIX_PATTERN =
+      Pattern.compile("^(dpop|bearer)(\\s+)(.+)$", Pattern.CASE_INSENSITIVE);
+
+  private final TigerProxy tigerProxy;
+  private final JwtManipulationConfiguration configuration;
+
+  /** Create a request-scoped helper for one immutable manipulation configuration snapshot. */
+  private JwtManipulationCallback(
+      TigerProxy tigerProxy, JwtManipulationConfiguration configuration) {
+    this.tigerProxy = tigerProxy;
+    this.configuration = configuration;
+  }
+
+  /**
+   * Build a request-scoped helper from the proxy's current configuration so concurrent proxies do
+   * not share static manipulation state.
+   */
+  public static void applyJwtManipulationIfConfigured(TigerProxy tigerProxy, HttpRequest request) {
+    tigerProxy
+        .getJwtManipulationConfiguration()
+        .ifPresent(
+            configuration ->
+                new JwtManipulationCallback(tigerProxy, configuration).applyJwtManipulation(request));
+  }
+
+  /**
+   * Applies the configured JWT manipulation to the given request, including optional request
+   * filtering, token re-signing, DPoP {@code ath} recalculation, and execution-limit handling.
+   */
+  public void applyJwtManipulation(HttpRequest request) {
+    if (configuration.getJwtLocation() == null
+        || configuration.getJwtField() == null
+        || configuration.getReplaceWith() == null) {
+      return;
+    }
+
+    try {
+      // Apply the optional request filter before touching the JWT.
+      if (configuration.getCondition() != null
+          && !configuration.getCondition().isBlank()
+          && !matchesCondition(request)) {
+        log.debug("Condition not matched for request");
+        return;
+      }
+
+      // jwtLocation identifies the HTTP container that holds the JWT, for example
+      // $.header.authorization or $.body.client_assertion.
+      String[] locationParts = configuration.getJwtLocation().split("\\.");
+      if (locationParts.length < 3 || !"$".equals(locationParts[0])) {
+        log.warn("Invalid jwtLocation format: {}", configuration.getJwtLocation());
+        return;
+      }
+
+      String httpPart = locationParts[1];
+      String containerName = normalizeLocationSegment(locationParts[2]);
+
+      // jwtField identifies the JWT section plus the field path inside that section, for example
+      // body.client_statement.platform or body.aud.0.
+      String[] fieldParts = configuration.getJwtField().split("\\.", 2);
+      if (fieldParts.length < 2) {
+        log.warn("Invalid jwtField format: {}", configuration.getJwtField());
+        return;
+      }
+
+      String jwtPart = fieldParts[0];
+      String fieldPath = fieldParts[1];
+
+      // Treat a numeric last segment as an array index so paths like aud.0 can target a single
+      // element while the remaining prefix still addresses the array field itself.
+      Integer arrayIndex = null;
+      String fieldName = fieldPath;
+      String[] pathParts = fieldPath.split("\\.");
+      if (pathParts.length >= 2) {
+        String lastPart = pathParts[pathParts.length - 1];
+        try {
+          arrayIndex = Integer.parseInt(lastPart);
+          fieldName = fieldPath.substring(0, fieldPath.lastIndexOf('.'));
+        } catch (NumberFormatException e) {
+          fieldName = fieldPath;
+        }
+      }
+
+      String manipulatedJwt = null;
+      if ("header".equals(httpPart)) {
+        manipulatedJwt = manipulateHeaderJwt(request, containerName, jwtPart, fieldName, arrayIndex);
+      } else if ("body".equals(httpPart)) {
+        manipulateBodyJwt(request, containerName, jwtPart, fieldName, arrayIndex);
+      }
+
+      log.info(
+          "JWT manipulation applied: {} {} = {}",
+          configuration.getJwtLocation(),
+          configuration.getJwtField(),
+          configuration.getReplaceWith());
+
+      // Manipulating the access token invalidates the DPoP ath claim, so recalculate it when the
+      // request also carries a DPoP proof.
+      if (manipulatedJwt != null && "authorization".equalsIgnoreCase(containerName)) {
+        updateDpopAth(request, manipulatedJwt);
+      }
+
+      // deleteAfterNExecutions is tracked on the proxy instance so separate proxies do not share
+      // execution counters.
+      if (configuration.getDeleteAfterNExecutions() != null
+          && tigerProxy.recordJwtManipulationExecutionAndClearIfNeeded()) {
+        log.info(
+            "JWT manipulation reached configured execution limit {}, clearing configuration",
+            configuration.getDeleteAfterNExecutions());
+      }
+    } catch (Exception e) {
+      log.error("Failed to apply JWT manipulation: {}", e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Supports path regexes, body-field equality/regex checks, and simple {@code &&}/{@code ||}
+   * combinations.
+   */
+  private boolean matchesCondition(HttpRequest request) {
+    String conditionStr = configuration.getCondition().trim();
+
+    if (conditionStr.contains("&&")) {
+      String[] parts = splitConditionOperator(conditionStr, "&&");
+      for (String part : parts) {
+        if (!evaluateSingleCondition(request, part.trim())) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    if (conditionStr.contains("||")) {
+      String[] parts = splitConditionOperator(conditionStr, "||");
+      for (String part : parts) {
+        if (evaluateSingleCondition(request, part.trim())) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    return evaluateSingleCondition(request, conditionStr);
+  }
+
+  /** Evaluate one non-composite condition against the current request. */
+  private static boolean evaluateSingleCondition(HttpRequest request, String conditionStr) {
+    try {
+      if (conditionStr.contains("message.path") && conditionStr.contains("=~")) {
+        String pattern = extractQuotedValue(conditionStr.substring(conditionStr.indexOf("=~") + 2));
+        String requestPath = request.getPath() != null ? request.getPath() : "";
+        boolean matches = requestPath.matches(pattern);
+        log.debug(
+            "Path condition: pattern='{}', requestPath='{}', matches={}",
+            pattern,
+            requestPath,
+            matches);
+        return matches;
+      }
+
+      if (conditionStr.contains("message.body.")
+          && (conditionStr.contains("==") || conditionStr.contains("=~"))) {
+        int bodyIdx = conditionStr.indexOf("message.body.") + "message.body.".length();
+        boolean isRegex = conditionStr.contains("=~");
+        String operator = isRegex ? "=~" : "==";
+        int opIdx = conditionStr.indexOf(operator);
+        String paramName = conditionStr.substring(bodyIdx, opIdx).trim();
+        String expectedValue =
+            extractQuotedValue(conditionStr.substring(opIdx + operator.length()));
+
+        String bodyStr = getBodyAsString(request);
+        if (bodyStr == null) {
+          log.debug("Body condition: paramName='{}', body is null, matches=false", paramName);
+          return false;
+        }
+
+        String actualValue = extractFormParameter(bodyStr, paramName);
+        if (actualValue != null) {
+          boolean matches =
+              isRegex ? actualValue.matches(expectedValue) : actualValue.equals(expectedValue);
+          log.debug(
+              "Body condition (form): paramName='{}', expectedValue='{}', actualValue='{}', isRegex={}, matches={}",
+              paramName,
+              expectedValue,
+              actualValue,
+              isRegex,
+              matches);
+          return matches;
+        }
+
+        try {
+          JsonNode bodyNode = mapper.readTree(bodyStr);
+          if (bodyNode.has(paramName)) {
+            String jsonValue = bodyNode.get(paramName).asText();
+            boolean matches =
+                isRegex ? jsonValue.matches(expectedValue) : jsonValue.equals(expectedValue);
+            log.debug(
+                "Body condition (json): paramName='{}', expectedValue='{}', actualValue='{}', isRegex={}, matches={}",
+                paramName,
+                expectedValue,
+                jsonValue,
+                isRegex,
+                matches);
+            return matches;
+          }
+        } catch (Exception e) {
+          log.debug("Body is not JSON, parameter {} not found", paramName);
+        }
+
+        log.debug("Body condition: paramName='{}' not found in body", paramName);
+        return false;
+      }
+
+      String pattern = extractQuotedValue(conditionStr);
+      String requestPath = request.getPath() != null ? request.getPath() : "";
+      try {
+        return requestPath.matches(pattern);
+      } catch (PatternSyntaxException e) {
+        log.warn("Invalid regex pattern in condition: {}", pattern, e);
+        return false;
+      }
+    } catch (Exception e) {
+      log.warn("Failed to evaluate condition: {}", conditionStr, e);
+      return false;
+    }
+  }
+
+  /** Remove optional surrounding single or double quotes from a condition fragment. */
+  private static String extractQuotedValue(String str) {
+    String trimmed = str.trim();
+    if ((trimmed.startsWith("'") && trimmed.endsWith("'"))
+        || (trimmed.startsWith("\"") && trimmed.endsWith("\""))) {
+      return trimmed.substring(1, trimmed.length() - 1);
+    }
+    return trimmed;
+  }
+
+  /**
+   * Normalize one location segment from {@code $.header.foo} or bracketed variants such as
+   * {@code $.header.[~'DPoP']} to the raw header/body field name.
+   */
+  private static String normalizeLocationSegment(String segment) {
+    String normalized = segment.trim();
+    boolean bracketedSegment = false;
+    if (normalized.startsWith("[") && normalized.endsWith("]")) {
+      bracketedSegment = true;
+      normalized = normalized.substring(1, normalized.length() - 1).trim();
+    }
+    if (bracketedSegment && normalized.startsWith("~")) {
+      normalized = normalized.substring(1).trim();
+    }
+    if ((normalized.startsWith("'") && normalized.endsWith("'"))
+        || (normalized.startsWith("\"") && normalized.endsWith("\""))) {
+      normalized = normalized.substring(1, normalized.length() - 1);
+    }
+    return normalized;
+  }
+
+  /** Read the request body as UTF-8 text when present. */
+  private static String getBodyAsString(HttpRequest request) {
+    byte[] bodyBytes = request.getBody();
+    if (bodyBytes == null || bodyBytes.length == 0) {
+      return null;
+    }
+    return new String(bodyBytes, StandardCharsets.UTF_8);
+  }
+
+  /** Extract one form parameter from an {@code application/x-www-form-urlencoded} body. */
+  private static String extractFormParameter(String body, String paramName) {
+    // Extract a parameter from an application/x-www-form-urlencoded body.
+    Pattern pattern = Pattern.compile("(^|&)" + Pattern.quote(paramName) + "=([^&]+)");
+    Matcher matcher = pattern.matcher(body);
+    if (matcher.find()) {
+      try {
+        return URLDecoder.decode(matcher.group(2), StandardCharsets.UTF_8);
+      } catch (Exception e) {
+        return matcher.group(2);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Recalculate the DPoP {@code ath} claim after the access token was manipulated and re-sign the
+   * proof JWT.
+   */
+  private void updateDpopAth(HttpRequest request, String manipulatedAccessToken) {
+    if (!Boolean.TRUE.equals(configuration.getUpdateAth())
+        || configuration.getDpopLocation() == null
+        || configuration.getDpopPrivateKeyPem() == null) {
+      return;
+    }
+
+    try {
+      String[] locationParts = configuration.getDpopLocation().split("\\.");
+      if (locationParts.length < 3 || !"$".equals(locationParts[0])) {
+        log.warn("Invalid dpopLocation format: {}", configuration.getDpopLocation());
+        return;
+      }
+
+      String httpPart = locationParts[1];
+      String containerName = normalizeLocationSegment(locationParts[2]);
+
+      if (!"header".equals(httpPart)) {
+        log.warn("DPoP is expected in header, got: {}", httpPart);
+        return;
+      }
+
+      String dpopHeaderValue = getHeaderValue(request, containerName);
+      if (dpopHeaderValue == null) {
+        log.debug("DPoP header {} not found in request", containerName);
+        return;
+      }
+
+      String prefix = extractJwtHeaderPrefix(dpopHeaderValue);
+      String dpopJwt = extractCompactJwt(dpopHeaderValue);
+
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(manipulatedAccessToken.getBytes(StandardCharsets.US_ASCII));
+      String newAth = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+
+      String[] parts = dpopJwt.split("\\.");
+      if (parts.length != 3) {
+        log.warn("Invalid DPoP JWT format");
+        return;
+      }
+
+      String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]));
+      String bodyJson = new String(Base64.getUrlDecoder().decode(parts[1]));
+      ObjectNode headerNode = (ObjectNode) mapper.readTree(headerJson);
+      ObjectNode bodyNode = (ObjectNode) mapper.readTree(bodyJson);
+
+      bodyNode.put("ath", newAth);
+      log.info("Updated DPoP ath to: {}", newAth);
+
+      ECPrivateKey dpopPrivateKey = parseEcPrivateKey(configuration.getDpopPrivateKeyPem());
+
+      String newHeaderB64 =
+          Base64.getUrlEncoder()
+              .withoutPadding()
+              .encodeToString(mapper.writeValueAsBytes(headerNode));
+      String newBodyB64 =
+          Base64.getUrlEncoder()
+              .withoutPadding()
+              .encodeToString(mapper.writeValueAsBytes(bodyNode));
+
+      String signingInput = newHeaderB64 + "." + newBodyB64;
+
+      byte[] signatureBytes = signEs256(signingInput, dpopPrivateKey);
+      String signatureB64 =
+          Base64.getUrlEncoder().withoutPadding().encodeToString(signatureBytes);
+
+      String newDpopJwt = signingInput + "." + signatureB64;
+
+      updateHeader(request, containerName, prefix + newDpopJwt);
+      log.info("DPoP JWT updated with new ath");
+    } catch (Exception e) {
+      log.error("Failed to update DPoP ath: {}", e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Manipulate a JWT stored in an HTTP header and keep the original authentication prefix such as
+   * {@code Bearer } or {@code DPoP }.
+   *
+   * @return the manipulated JWT without the prefix, or {@code null} when the header is absent
+   */
+  private String manipulateHeaderJwt(
+      HttpRequest request, String headerName, String jwtPart, String fieldName, Integer arrayIndex)
+      throws Exception {
+    String headerValue = getHeaderValue(request, headerName);
+    if (headerValue == null) {
+      log.debug("Header {} not found in request", headerName);
+      return null;
+    }
+
+    String prefix = extractJwtHeaderPrefix(headerValue);
+    String jwt = extractCompactJwt(headerValue);
+    String manipulatedJwt = manipulateJwt(jwt, jwtPart, fieldName, arrayIndex);
+    updateHeader(request, headerName, prefix + manipulatedJwt);
+    return manipulatedJwt;
+  }
+
+  /** Manipulate a JWT stored in the request body and update the serialized payload in-place. */
+  private void manipulateBodyJwt(
+      HttpRequest request,
+      String containerName,
+      String jwtPart,
+      String fieldName,
+      Integer arrayIndex)
+      throws Exception {
+    byte[] bodyBytes = request.getBody();
+    if (bodyBytes == null || bodyBytes.length == 0) {
+      log.debug("Request body is empty");
+      return;
+    }
+
+    String body = new String(bodyBytes, StandardCharsets.UTF_8);
+    String contentType = getHeaderValue(request, "content-type");
+
+    // Token endpoints commonly send JWTs either as JSON fields or as form parameters.
+    String newBody;
+    if (contentType != null && contentType.contains("application/json")) {
+      newBody = manipulateJsonBody(body, containerName, jwtPart, fieldName, arrayIndex);
+    } else {
+      newBody = manipulateFormBody(body, containerName, jwtPart, fieldName, arrayIndex);
+    }
+
+    byte[] newBodyBytes = newBody.getBytes(StandardCharsets.UTF_8);
+    request.withBody(newBodyBytes);
+    // Keep Content-Length in sync after in-place body manipulation.
+    updateHeader(request, "Content-Length", String.valueOf(newBodyBytes.length));
+  }
+
+  /** Manipulate a JWT stored in a JSON body field. */
+  private String manipulateJsonBody(
+      String body, String containerName, String jwtPart, String fieldName, Integer arrayIndex)
+      throws Exception {
+    JsonNode rootNode = mapper.readTree(body);
+    if (!rootNode.has(containerName)) {
+      log.debug("JSON field {} not found in body", containerName);
+      return body;
+    }
+
+    String jwt = rootNode.get(containerName).asText();
+    String manipulatedJwt = manipulateJwt(jwt, jwtPart, fieldName, arrayIndex);
+
+    ((ObjectNode) rootNode).put(containerName, manipulatedJwt);
+    return mapper.writeValueAsString(rootNode);
+  }
+
+  /** Manipulate a JWT stored in a form body parameter. */
+  private String manipulateFormBody(
+      String body, String containerName, String jwtPart, String fieldName, Integer arrayIndex)
+      throws Exception {
+    Pattern pattern = Pattern.compile("(^|&)" + Pattern.quote(containerName) + "=([^&]+)");
+    Matcher matcher = pattern.matcher(body);
+
+    if (!matcher.find()) {
+      log.debug("Form parameter {} not found in body", containerName);
+      return body;
+    }
+
+    String jwt = URLDecoder.decode(matcher.group(2), StandardCharsets.UTF_8);
+    String manipulatedJwt = manipulateJwt(jwt, jwtPart, fieldName, arrayIndex);
+    String encodedJwt = URLEncoder.encode(manipulatedJwt, StandardCharsets.UTF_8);
+
+    return body.substring(0, matcher.start(2)) + encodedJwt + body.substring(matcher.end(2));
+  }
+
+  /** Read one request header value using case-insensitive header-name matching. */
+  private static String getHeaderValue(HttpRequest request, String headerName) {
+    var headers = request.getHeaderList();
+    for (var header : headers) {
+      if (header.getName().equalsIgnoreCase(headerName)) {
+        return header.getValues().get(0);
+      }
+    }
+    return null;
+  }
+
+  /** Replace a request header value while preserving the rest of the request. */
+  private static void updateHeader(HttpRequest request, String headerName, String newValue) {
+    request.removeHeader(headerName);
+    request.withHeader(headerName, newValue);
+  }
+
+  /**
+   * Return the original authentication prefix from a header JWT value, for example {@code dpop }
+   * or {@code Bearer }.
+   */
+  private static String extractJwtHeaderPrefix(String headerValue) {
+    Matcher matcher = JWT_HEADER_PREFIX_PATTERN.matcher(headerValue);
+    if (matcher.matches()) {
+      return matcher.group(1) + matcher.group(2);
+    }
+    return "";
+  }
+
+  /** Return the compact JWT part from an HTTP header value with an optional auth scheme prefix. */
+  private static String extractCompactJwt(String headerValue) {
+    Matcher matcher = JWT_HEADER_PREFIX_PATTERN.matcher(headerValue);
+    if (matcher.matches()) {
+      return matcher.group(3);
+    }
+    return headerValue;
+  }
+
+  /** Modify one JWT field and optionally re-sign the compact JWT afterwards. */
+  private String manipulateJwt(String jwt, String jwtPart, String fieldName, Integer arrayIndex)
+      throws Exception {
+    String[] parts = jwt.split("\\.", -1);
+    if (parts.length != 3) {
+      throw new IllegalArgumentException(
+          "Invalid JWT format: expected 3 parts, got " + parts.length);
+    }
+
+    if ("variant".equals(jwtPart)) {
+      return buildJwtVariant(jwt, parts);
+    }
+
+    String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]));
+    String bodyJson = new String(Base64.getUrlDecoder().decode(parts[1]));
+    ObjectNode headerNode = (ObjectNode) mapper.readTree(headerJson);
+    ObjectNode bodyNode = (ObjectNode) mapper.readTree(bodyJson);
+
+    if ("header".equals(jwtPart)) {
+      setJsonValue(headerNode, fieldName, configuration.getReplaceWith(), arrayIndex);
+    } else if ("body".equals(jwtPart)) {
+      setJsonValue(bodyNode, fieldName, configuration.getReplaceWith(), arrayIndex);
+    }
+
+    String newHeaderB64 =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(mapper.writeValueAsBytes(headerNode));
+    String newBodyB64 =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(mapper.writeValueAsBytes(bodyNode));
+
+    if (configuration.getPrivateKeyPem() != null && !configuration.getPrivateKeyPem().isBlank()) {
+      return signJwt(headerNode, bodyNode);
+    }
+    return newHeaderB64 + "." + newBodyB64 + "." + parts[2];
+  }
+
+  /** Build a malformed compact JWT variant from the live intercepted token. */
+  private String buildJwtVariant(String jwt, String[] parts) throws Exception {
+    var variant = configuration.getReplaceWith().trim().toLowerCase(Locale.ROOT);
+    String headerJson = decodeBase64UrlSegment(parts[0], "header");
+    String bodyJson = decodeBase64UrlSegment(parts[1], "body");
+
+    return switch (variant) {
+      case "two_segments" -> parts[0] + "." + parts[1];
+      case "invalid_header_base64url" -> "###." + parts[1] + "." + parts[2];
+      case "invalid_payload_base64url" -> parts[0] + ".###." + parts[2];
+      case "invalid_signature_base64url" -> parts[0] + "." + parts[1] + ".###";
+      case "invalid_header_json" -> encodeBase64Url("{") + "." + parts[1] + "." + parts[2];
+      case "invalid_payload_json" -> parts[0] + "." + encodeBase64Url("{") + "." + parts[2];
+      case "jwe_like_five_segments" -> parts[0]
+          + ".ZW5jcnlwdGVkS2V5.aXY.Y2lwaGVydGV4dA.dGFn";
+      case "unknown_header_parameter" -> signCompactJwt(
+          addUnknownHeaderParameter(headerJson), bodyJson);
+      case "unsupported_crit" -> signCompactJwt(addUnsupportedCritHeader(headerJson), bodyJson);
+      case "unsupported_alg" -> signCompactJwt(
+          replaceTopLevelHeaderParameter(headerJson, "alg", "RS999"), bodyJson);
+      case "missing_alg" -> signCompactJwt(removeTopLevelHeaderParameter(headerJson, "alg"),
+          bodyJson);
+      case "duplicate_alg_headers" -> signCompactJwt(duplicateAlgHeader(headerJson), bodyJson);
+      case "invalid_signature" -> createInvalidSignatureVariant(headerJson, bodyJson, parts[2]);
+      case "nested_cty_jwt_valid_inner" -> signCompactJwt(addNestedJwtContentType(headerJson),
+          jwt);
+      case "nested_cty_jwt_invalid_inner" -> signCompactJwt(addNestedJwtContentType(headerJson),
+          "###.eyJpc3MiOiJ6ZXRhLXRlc3QifQ.signature");
+      default -> throw new IllegalArgumentException("Unknown JWT variant: " + variant);
+    };
+  }
+
+  /** Decode a Base64URL compact JWT segment into UTF-8 text. */
+  private static String decodeBase64UrlSegment(String segment, String description) {
+    try {
+      return new String(Base64.getUrlDecoder().decode(segment), StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Failed to decode JWT " + description + " segment", e);
+    }
+  }
+
+  /** Encode UTF-8 text as unpadded Base64URL. */
+  private static String encodeBase64Url(String value) {
+    return Base64.getUrlEncoder().withoutPadding()
+        .encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /** Add an unsupported non-critical JOSE header parameter. */
+  private static String addUnknownHeaderParameter(String headerJson) throws Exception {
+    var header = parseJsonObject(headerJson, "JOSE header");
+    header.put("unknown_guard_parameter", "unsupported");
+    return mapper.writeValueAsString(header);
+  }
+
+  /** Add an unsupported critical JOSE header parameter. */
+  private static String addUnsupportedCritHeader(String headerJson) throws Exception {
+    var header = parseJsonObject(headerJson, "JOSE header");
+    var crit = header.putArray("crit");
+    crit.add("unsupported_guard_parameter");
+    header.put("unsupported_guard_parameter", "requested-by-crit");
+    return mapper.writeValueAsString(header);
+  }
+
+  /** Replace a top-level JOSE header parameter with a string value. */
+  private static String replaceTopLevelHeaderParameter(String headerJson, String parameter,
+      String value) throws Exception {
+    var header = parseJsonObject(headerJson, "JOSE header");
+    header.put(parameter, value);
+    return mapper.writeValueAsString(header);
+  }
+
+  /** Remove a top-level JOSE header parameter. */
+  private static String removeTopLevelHeaderParameter(String headerJson, String parameter)
+      throws Exception {
+    var header = parseJsonObject(headerJson, "JOSE header");
+    header.remove(parameter);
+    return mapper.writeValueAsString(header);
+  }
+
+  /** Duplicate the top-level {@code alg} header member in the raw JOSE header JSON. */
+  private static String duplicateAlgHeader(String headerJson) {
+    var matcher = Pattern.compile("\"alg\"\\s*:\\s*\"[^\"]+\"").matcher(headerJson);
+    if (!matcher.find()) {
+      throw new IllegalArgumentException("Original JOSE header must contain an alg parameter");
+    }
+    return headerJson.substring(0, matcher.start())
+        + "\"alg\":\"ES384\","
+        + headerJson.substring(matcher.start());
+  }
+
+  /** Add {@code cty=JWT} to the JOSE header. */
+  private static String addNestedJwtContentType(String headerJson) throws Exception {
+    var header = parseJsonObject(headerJson, "JOSE header");
+    header.put("cty", "JWT");
+    return mapper.writeValueAsString(header);
+  }
+
+  /** Create a compact JWS with changed signing input and the unchanged original signature. */
+  private static String createInvalidSignatureVariant(String headerJson, String bodyJson,
+      String signaturePart) throws Exception {
+    var body = parseJsonObject(bodyJson, "JWT body");
+    body.put("broken_signature_marker", true);
+    return encodeBase64Url(headerJson) + "." + encodeBase64Url(mapper.writeValueAsString(body))
+        + "." + signaturePart;
+  }
+
+  /** Parse a JSON object or fail with a targeted message. */
+  private static ObjectNode parseJsonObject(String json, String description) throws Exception {
+    var node = mapper.readTree(json);
+    if (!node.isObject()) {
+      throw new IllegalArgumentException(description + " must be a JSON object");
+    }
+    return (ObjectNode) node;
+  }
+
+  /** Sign raw JOSE header and payload JSON with the configured EC private key. */
+  private String signCompactJwt(String headerJson, String bodyJson) throws Exception {
+    if (configuration.getPrivateKeyPem() == null || configuration.getPrivateKeyPem().isBlank()) {
+      throw new IllegalArgumentException("A private key is required for signed JWT variants");
+    }
+
+    parseJsonObject(headerJson, "JOSE header");
+    if (Boolean.TRUE.equals(configuration.getReplaceJwk())) {
+      java.security.interfaces.ECPublicKey publicKey = derivePublicKey(
+          parseEcPrivateKey(configuration.getPrivateKeyPem()));
+      headerJson = replaceJwkHeaderParameter(headerJson, toPublicJwkJson(publicKey));
+    }
+
+    var signingInput = encodeBase64Url(headerJson) + "." + encodeBase64Url(bodyJson);
+    ECPrivateKey privateKey = parseEcPrivateKey(configuration.getPrivateKeyPem());
+    byte[] signatureBytes = signEs256(signingInput, privateKey);
+    return signingInput + "." + Base64.getUrlEncoder().withoutPadding()
+        .encodeToString(signatureBytes);
+  }
+
+  /** Replace the top-level {@code jwk} header member while preserving raw header edge cases. */
+  private static String replaceJwkHeaderParameter(String headerJson, String jwkJson) {
+    var matcher = Pattern.compile("\"jwk\"\\s*:\\s*\\{[^{}]*}").matcher(headerJson);
+    if (matcher.find()) {
+      return headerJson.substring(0, matcher.start())
+          + "\"jwk\":"
+          + jwkJson
+          + headerJson.substring(matcher.end());
+    }
+
+    var trimmed = headerJson.trim();
+    if (!trimmed.startsWith("{")) {
+      throw new IllegalArgumentException("JOSE header must be a JSON object to replace jwk");
+    }
+    if (trimmed.endsWith("}") && trimmed.substring(1, trimmed.length() - 1).isBlank()) {
+      return "{" + "\"jwk\":" + jwkJson + "}";
+    }
+    return "{" + "\"jwk\":" + jwkJson + "," + trimmed.substring(1);
+  }
+
+  /** Apply a value change to a JSON field while preserving the current field shape when possible. */
+  private static void setJsonValue(
+      ObjectNode node, String key, String value, Integer arrayIndex) {
+    // Support dot-notation paths such as client_statement.platform in addition to top-level
+    // claims.
+    if (key.contains(".")) {
+      setNestedJsonValue(node, key, value, arrayIndex);
+      return;
+    }
+
+    if (node.has(key)) {
+      var existingNode = node.get(key);
+      if (existingNode.isBoolean()) {
+        node.put(key, Boolean.parseBoolean(value));
+      } else if (existingNode.isNumber()) {
+        node.put(key, Long.parseLong(value));
+      } else if (existingNode.isArray()) {
+        var arrayNode = (com.fasterxml.jackson.databind.node.ArrayNode) existingNode;
+        if (arrayIndex != null) {
+          if (arrayIndex >= 0 && arrayIndex < arrayNode.size()) {
+            arrayNode.set(arrayIndex, mapper.getNodeFactory().textNode(value));
+          } else {
+            arrayNode.add(value);
+          }
+          log.debug("Modified array element at index {}: {}", arrayIndex, value);
+        } else if (value.trim().startsWith("[")) {
+          try {
+            node.set(key, mapper.readTree(value));
+          } catch (Exception e) {
+            var newArray = mapper.createArrayNode();
+            newArray.add(value);
+            node.set(key, newArray);
+          }
+        } else {
+          var newArray = mapper.createArrayNode();
+          newArray.add(value);
+          node.set(key, newArray);
+        }
+      } else {
+        node.put(key, value);
+      }
+    } else {
+      node.put(key, value);
+    }
+  }
+
+  /**
+   * Set a nested JSON value using dot notation such as {@code client_statement.platform}. Missing
+   * intermediate objects are created on demand.
+   */
+  private static void setNestedJsonValue(
+      ObjectNode node, String path, String value, Integer arrayIndex) {
+    String[] pathParts = path.split("\\.");
+    ObjectNode currentNode = node;
+
+    for (int i = 0; i < pathParts.length - 1; i++) {
+      String part = pathParts[i];
+      if (!currentNode.has(part)) {
+        currentNode.set(part, mapper.createObjectNode());
+      } else if (!currentNode.get(part).isObject()) {
+        log.warn("Replacing non-object value at {} with object to support nested path", part);
+        currentNode.set(part, mapper.createObjectNode());
+      }
+      currentNode = (ObjectNode) currentNode.get(part);
+    }
+
+    String finalKey = pathParts[pathParts.length - 1];
+    if (currentNode.has(finalKey)) {
+      var existingNode = currentNode.get(finalKey);
+      if (existingNode.isBoolean()) {
+        currentNode.put(finalKey, Boolean.parseBoolean(value));
+      } else if (existingNode.isNumber()) {
+        try {
+          currentNode.put(finalKey, Long.parseLong(value));
+        } catch (NumberFormatException e) {
+          log.warn(
+              "Invalid numeric value '{}' for field '{}', treating as string", value, finalKey);
+          currentNode.put(finalKey, value);
+        }
+      } else if (existingNode.isArray() && arrayIndex != null) {
+        var arrayNode = (com.fasterxml.jackson.databind.node.ArrayNode) existingNode;
+        if (arrayIndex >= 0 && arrayIndex < arrayNode.size()) {
+          arrayNode.set(arrayIndex, mapper.getNodeFactory().textNode(value));
+        } else {
+          arrayNode.add(value);
+        }
+      } else {
+        currentNode.put(finalKey, value);
+      }
+    } else {
+      currentNode.put(finalKey, value);
+    }
+    log.info("Set nested value: {} = {}", path, value);
+  }
+
+  /** Re-sign a manipulated JWT with the configured EC private key. */
+  private String signJwt(ObjectNode headerNode, ObjectNode bodyNode) throws Exception {
+    ECPrivateKey privateKey = parseEcPrivateKey(configuration.getPrivateKeyPem());
+
+    // Replace the embedded JWK only when explicitly requested for negative-test scenarios.
+    if (Boolean.TRUE.equals(configuration.getReplaceJwk())) {
+      java.security.interfaces.ECPublicKey publicKey = derivePublicKey(privateKey);
+      headerNode.set("jwk", mapper.readTree(toPublicJwkJson(publicKey)));
+      log.info("JWK replaced with public key derived from provided private key");
+    }
+
+    // Build the compact JWT manually so tests can keep a manipulated header.alg value while we
+    // still sign with ES256.
+    String headerJson = mapper.writeValueAsString(headerNode);
+    String bodyJson = mapper.writeValueAsString(bodyNode);
+
+    String headerB64 =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(headerJson.getBytes(StandardCharsets.UTF_8));
+    String bodyB64 =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(bodyJson.getBytes(StandardCharsets.UTF_8));
+
+    String signingInput = headerB64 + "." + bodyB64;
+
+    byte[] signatureBytes = signEs256(signingInput, privateKey);
+
+    String signatureB64 =
+        Base64.getUrlEncoder().withoutPadding().encodeToString(signatureBytes);
+
+    return signingInput + "." + signatureB64;
+  }
+
+  /** Serialize an EC public key as a public JWK using the jose4j stack already used by RBEL. */
+  private static String toPublicJwkJson(java.security.interfaces.ECPublicKey publicKey) {
+    return new EllipticCurveJsonWebKey(publicKey).toJson(JsonWebKey.OutputControlLevel.PUBLIC_ONLY);
+  }
+
+  /** Sign a pre-built compact-JWS signing input with ES256 and return JOSE raw R/S bytes. */
+  private static byte[] signEs256(String signingInput, ECPrivateKey privateKey) throws Exception {
+    Signature signature = Signature.getInstance("SHA256withECDSA");
+    signature.initSign(privateKey);
+    signature.update(signingInput.getBytes(StandardCharsets.UTF_8));
+    return EcdsaUsingShaAlgorithm.convertDerToConcatenated(signature.sign(), 64);
+  }
+
+  /** Derive the corresponding P-256 public key from the configured EC private key. */
+  private static java.security.interfaces.ECPublicKey derivePublicKey(ECPrivateKey privateKey)
+      throws Exception {
+    org.bouncycastle.jce.spec.ECParameterSpec bcSpec =
+        org.bouncycastle.jce.ECNamedCurveTable.getParameterSpec("P-256");
+    org.bouncycastle.math.ec.ECPoint q = bcSpec.getG().multiply(privateKey.getS()).normalize();
+
+    java.security.spec.ECPoint pubPoint =
+        new java.security.spec.ECPoint(
+            q.getAffineXCoord().toBigInteger(), q.getAffineYCoord().toBigInteger());
+
+    java.security.spec.ECPublicKeySpec pubSpec =
+        new java.security.spec.ECPublicKeySpec(pubPoint, privateKey.getParams());
+    KeyFactory kf = KeyFactory.getInstance("EC");
+    return (java.security.interfaces.ECPublicKey) kf.generatePublic(pubSpec);
+  }
+
+  /** Parse an EC private key from PEM or raw PKCS#8 base64 input. */
+  private static ECPrivateKey parseEcPrivateKey(String pemValue) throws Exception {
+    if (pemValue == null || pemValue.isBlank()) {
+      throw new IllegalArgumentException("EC private key must not be empty");
+    }
+
+    // Accept PEM-encoded keys as well as raw base64 PKCS#8 to preserve compatibility with the
+    // existing test inputs and controller payloads.
+    String trimmedValue = pemValue.trim();
+
+    if (trimmedValue.startsWith("-----BEGIN")) {
+      try (PEMParser pemParser = new PEMParser(new StringReader(trimmedValue))) {
+        Object parsedObject = pemParser.readObject();
+        if (parsedObject == null) {
+          throw new IllegalArgumentException("EC private key PEM could not be parsed");
+        }
+
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("SunEC");
+        PrivateKey privateKey;
+        log.info("PEM parsed object type: {}", parsedObject.getClass().getSimpleName());
+        if (parsedObject instanceof PEMKeyPair pemKeyPair) {
+          privateKey = converter.getPrivateKey(pemKeyPair.getPrivateKeyInfo());
+        } else if (parsedObject instanceof PrivateKeyInfo privateKeyInfo) {
+          privateKey = converter.getPrivateKey(privateKeyInfo);
+        } else {
+          throw new IllegalArgumentException(
+              "Unsupported EC private key format: "
+                  + parsedObject.getClass().getSimpleName());
+        }
+
+        log.info(
+            "Converted key type: {}, algorithm: {}",
+            privateKey.getClass().getSimpleName(),
+            privateKey.getAlgorithm());
+        if (!(privateKey instanceof ECPrivateKey ecPrivateKey)) {
+          throw new IllegalArgumentException(
+              "Provided key is not an EC private key, got: "
+                  + privateKey.getClass().getSimpleName()
+                  + " with algorithm: "
+                  + privateKey.getAlgorithm());
+        }
+        return ecPrivateKey;
+      } catch (IllegalArgumentException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Failed to parse EC private key: " + e.getMessage(), e);
+      }
+    }
+
+    return decodePkcs8Base64(trimmedValue);
+  }
+
+  /** Decode a raw PKCS#8 base64 EC private key. */
+  private static ECPrivateKey decodePkcs8Base64(String base64Key) throws Exception {
+    byte[] decoded = Base64.getDecoder().decode(base64Key.replaceAll("\\s", ""));
+    PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(decoded);
+    KeyFactory kf = KeyFactory.getInstance("EC");
+    return (ECPrivateKey) kf.generatePrivate(spec);
+  }
+
+  /**
+   * Split a condition string by an operator while ignoring operator tokens that appear inside
+   * quoted string literals.
+   */
+  private static String[] splitConditionOperator(String conditionStr, String operator) {
+    java.util.List<String> parts = new java.util.ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    boolean inQuotes = false;
+    char quoteChar = 0;
+
+    for (int i = 0; i < conditionStr.length(); i++) {
+      char c = conditionStr.charAt(i);
+
+      if ((c == '"' || c == '\'') && (i == 0 || conditionStr.charAt(i - 1) != '\\')) {
+        if (!inQuotes) {
+          inQuotes = true;
+          quoteChar = c;
+        } else if (c == quoteChar) {
+          inQuotes = false;
+        }
+        current.append(c);
+      } else if (!inQuotes
+          && i + operator.length() <= conditionStr.length()
+          && conditionStr.startsWith(operator, i)) {
+        parts.add(current.toString());
+        current = new StringBuilder();
+        i += operator.length() - 1;
+      } else {
+        current.append(c);
+      }
+    }
+
+    if (!current.isEmpty()) {
+      parts.add(current.toString());
+    }
+
+    return parts.toArray(new String[0]);
+  }
+}

--- a/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/handler/ReverseProxyCallback.java
+++ b/tiger-proxy/src/main/java/de/gematik/test/tiger/proxy/handler/ReverseProxyCallback.java
@@ -41,6 +41,7 @@ public class ReverseProxyCallback extends AbstractRouteProxyCallback {
 
   @Override
   public HttpRequest handleRequest(HttpRequest httpRequest) {
+    getTigerProxy().applyJwtManipulationIfConfigured(httpRequest);
     applyModifications(httpRequest);
     final HttpRequest request =
         cloneRequest(httpRequest)

--- a/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/TigerProxyJwtManipulationIsolationTest.java
+++ b/tiger-proxy/src/test/java/de/gematik/test/tiger/proxy/TigerProxyJwtManipulationIsolationTest.java
@@ -1,0 +1,369 @@
+/*
+ *
+ * Copyright 2021-2025 gematik GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * *******
+ *
+ * For additional notes and disclaimer from gematik and in case of changes by gematik find details in the "Readme" file.
+ */
+package de.gematik.test.tiger.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.gematik.test.tiger.common.data.config.tigerproxy.TigerProxyConfiguration;
+import de.gematik.test.tiger.mockserver.model.HttpRequest;
+import de.gematik.test.tiger.proxy.data.JwtManipulationConfiguration;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TigerProxyJwtManipulationIsolationTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  /** Verify that one proxy instance's JWT manipulation state does not leak into another instance. */
+  @Test
+  void applyJwtManipulationIfConfigured_shouldNotLeakAcrossProxyInstances() throws Exception {
+    try (TigerProxy manipulatingProxy =
+            new TigerProxy(TigerProxyConfiguration.builder().build());
+        TigerProxy untouchedProxy = new TigerProxy(TigerProxyConfiguration.builder().build())) {
+      manipulatingProxy.configureJwtManipulation(
+          JwtManipulationConfiguration.builder()
+              .jwtLocation("$.header.authorization")
+              .jwtField("body.sub")
+              .replaceWith("mutated-sub")
+              .build());
+
+      String originalJwt = createUnsignedJwt(Map.of("alg", "none"), Map.of("sub", "original-sub"));
+      HttpRequest manipulatedRequest =
+          HttpRequest.request("/hello").withHeader("Authorization", "Bearer " + originalJwt);
+      HttpRequest untouchedRequest =
+          HttpRequest.request("/hello").withHeader("Authorization", "Bearer " + originalJwt);
+
+      manipulatingProxy.applyJwtManipulationIfConfigured(manipulatedRequest);
+      untouchedProxy.applyJwtManipulationIfConfigured(untouchedRequest);
+
+      assertThat(extractJwtFromAuthorization(manipulatedRequest))
+          .isNotEqualTo(originalJwt)
+          .satisfies(jwt -> assertThat(extractBodyClaim(jwt, "sub")).isEqualTo("mutated-sub"));
+      assertThat(extractJwtFromAuthorization(untouchedRequest)).isEqualTo(originalJwt);
+      assertThat(untouchedProxy.hasActiveJwtManipulation()).isFalse();
+    }
+  }
+
+  /** Verify that lowercase {@code dpop } Authorization prefixes are manipulated correctly. */
+  @Test
+  void applyJwtManipulationIfConfigured_shouldHandleLowercaseDpopAuthorizationPrefix()
+      throws Exception {
+    try (TigerProxy manipulatingProxy = new TigerProxy(TigerProxyConfiguration.builder().build())) {
+      manipulatingProxy.configureJwtManipulation(
+          JwtManipulationConfiguration.builder()
+              .jwtLocation("$.header.authorization")
+              .jwtField("body.sub")
+              .replaceWith("mutated-sub")
+              .build());
+
+      String originalJwt = createUnsignedJwt(Map.of("alg", "none"), Map.of("sub", "original-sub"));
+      HttpRequest manipulatedRequest =
+          HttpRequest.request("/hello").withHeader("Authorization", "dpop " + originalJwt);
+
+      manipulatingProxy.applyJwtManipulationIfConfigured(manipulatedRequest);
+
+      assertThat(manipulatedRequest.getFirstHeader("Authorization")).startsWith("dpop ");
+      assertThat(extractJwtFromAuthorization(manipulatedRequest))
+          .isNotEqualTo(originalJwt)
+          .satisfies(jwt -> assertThat(extractBodyClaim(jwt, "sub")).isEqualTo("mutated-sub"));
+    }
+  }
+
+  /** Verify that bracketed DPoP header locations update the DPoP {@code ath} claim. */
+  @Test
+  void applyJwtManipulationIfConfigured_shouldUpdateAthForBracketedDpopHeaderLocation()
+      throws Exception {
+    try (TigerProxy manipulatingProxy = new TigerProxy(TigerProxyConfiguration.builder().build())) {
+      manipulatingProxy.configureJwtManipulation(
+          JwtManipulationConfiguration.builder()
+              .jwtLocation("$.header.authorization")
+              .jwtField("body.sub")
+              .replaceWith("mutated-sub")
+              .dpopLocation("$.header.[~'DPoP']")
+              .dpopPrivateKeyPem(TEST_EC_PRIVATE_KEY_PEM)
+              .updateAth(true)
+              .build());
+
+      String originalAccessToken =
+          createUnsignedJwt(Map.of("alg", "none"), Map.of("sub", "original-sub"));
+      String originalDpopJwt =
+          createUnsignedJwt(Map.of("alg", "ES256"), Map.of("ath", "stale-ath"));
+      HttpRequest manipulatedRequest =
+          HttpRequest.request("/hello")
+              .withHeader("Authorization", "Bearer " + originalAccessToken)
+              .withHeader("DPoP", originalDpopJwt);
+
+      manipulatingProxy.applyJwtManipulationIfConfigured(manipulatedRequest);
+
+      String manipulatedAccessToken = extractJwtFromAuthorization(manipulatedRequest);
+      String manipulatedDpopJwt = extractJwtFromHeaderValue(manipulatedRequest.getFirstHeader("DPoP"));
+
+      assertThat(extractBodyClaim(manipulatedAccessToken, "sub")).isEqualTo("mutated-sub");
+      assertThat(extractBodyClaim(manipulatedDpopJwt, "ath"))
+          .isEqualTo(calculateAth(manipulatedAccessToken));
+    }
+  }
+
+  /** Verify that plain dot-path locations preserve literal leading {@code ~} characters. */
+  @Test
+  void applyJwtManipulationIfConfigured_shouldPreserveLiteralLeadingTildeInHeaderLocation()
+      throws Exception {
+    try (TigerProxy manipulatingProxy = new TigerProxy(TigerProxyConfiguration.builder().build())) {
+      manipulatingProxy.configureJwtManipulation(
+          JwtManipulationConfiguration.builder()
+              .jwtLocation("$.header.~token")
+              .jwtField("body.sub")
+              .replaceWith("mutated-sub")
+              .build());
+
+      String originalJwt = createUnsignedJwt(Map.of("alg", "none"), Map.of("sub", "original-sub"));
+      HttpRequest manipulatedRequest =
+          HttpRequest.request("/hello").withHeader("~token", "Bearer " + originalJwt);
+
+      manipulatingProxy.applyJwtManipulationIfConfigured(manipulatedRequest);
+
+      assertThat(extractJwtFromHeaderValue(manipulatedRequest.getFirstHeader("~token")))
+          .isNotEqualTo(originalJwt)
+          .satisfies(jwt -> assertThat(extractBodyClaim(jwt, "sub")).isEqualTo("mutated-sub"));
+    }
+  }
+
+  /** Verify that composite {@code &&} conditions still match request path and body checks. */
+  @Test
+  void applyJwtManipulationIfConfigured_shouldMatchCompositeAndConditions() throws Exception {
+    try (TigerProxy manipulatingProxy = new TigerProxy(TigerProxyConfiguration.builder().build())) {
+      manipulatingProxy.configureJwtManipulation(
+          JwtManipulationConfiguration.builder()
+              .jwtLocation("$.header.authorization")
+              .jwtField("body.sub")
+              .replaceWith("mutated-sub")
+              .condition("message.path =~ '/token' && message.body.client_id == 'foo'")
+              .build());
+
+      String originalJwt = createUnsignedJwt(Map.of("alg", "none"), Map.of("sub", "original-sub"));
+      HttpRequest manipulatedRequest =
+          HttpRequest.request("/token")
+              .withHeader("Authorization", "Bearer " + originalJwt)
+              .withHeader("Content-Type", "application/json")
+              .withBody("{\"client_id\":\"foo\"}".getBytes(StandardCharsets.UTF_8));
+
+      manipulatingProxy.applyJwtManipulationIfConfigured(manipulatedRequest);
+
+      assertThat(extractJwtFromAuthorization(manipulatedRequest))
+          .isNotEqualTo(originalJwt)
+          .satisfies(jwt -> assertThat(extractBodyClaim(jwt, "sub")).isEqualTo("mutated-sub"));
+    }
+  }
+
+  /** Verify that compact JWT variants are built from the live body JWT. */
+  @Test
+  void applyJwtManipulationIfConfigured_shouldBuildTwoSegmentVariantFromLiveBodyJwt()
+      throws Exception {
+    try (TigerProxy manipulatingProxy = new TigerProxy(TigerProxyConfiguration.builder().build())) {
+      manipulatingProxy.configureJwtManipulation(
+          JwtManipulationConfiguration.builder()
+              .jwtLocation("$.body.client_assertion")
+              .jwtField("variant.name")
+              .replaceWith("two_segments")
+              .build());
+
+      String originalJwt = createUnsignedJwt(Map.of("alg", "none"), Map.of("sub", "live-sub"));
+      HttpRequest manipulatedRequest = createClientAssertionFormRequest(originalJwt);
+
+      manipulatingProxy.applyJwtManipulationIfConfigured(manipulatedRequest);
+
+      String[] parts = originalJwt.split("\\.", -1);
+      assertThat(extractClientAssertion(manipulatedRequest)).isEqualTo(parts[0] + "." + parts[1]);
+    }
+  }
+
+  /** Verify that nested live JWT variants wrap the current intercepted JWT. */
+  @Test
+  void applyJwtManipulationIfConfigured_shouldBuildNestedVariantFromLiveBodyJwt()
+      throws Exception {
+    try (TigerProxy manipulatingProxy = new TigerProxy(TigerProxyConfiguration.builder().build())) {
+      manipulatingProxy.configureJwtManipulation(
+          JwtManipulationConfiguration.builder()
+              .jwtLocation("$.body.client_assertion")
+              .jwtField("variant.name")
+              .replaceWith("nested_cty_jwt_valid_inner")
+              .privateKeyPem(TEST_EC_PRIVATE_KEY_PEM)
+              .replaceJwk(true)
+              .build());
+
+      String originalJwt = createUnsignedJwt(Map.of("alg", "ES256"), Map.of("sub", "live-sub"));
+      HttpRequest manipulatedRequest = createClientAssertionFormRequest(originalJwt);
+
+      manipulatingProxy.applyJwtManipulationIfConfigured(manipulatedRequest);
+
+      String nestedJwt = extractClientAssertion(manipulatedRequest);
+      assertThat(extractHeaderClaim(nestedJwt, "cty")).isEqualTo("JWT");
+      assertThat(decodeJwtBodyAsText(nestedJwt)).isEqualTo(originalJwt);
+      assertThat(decodeJwtHeaderAsText(nestedJwt)).contains("\"jwk\"");
+    }
+  }
+
+  /** Verify that duplicate {@code alg} variants keep both header members when replacing JWK. */
+  @Test
+  void applyJwtManipulationIfConfigured_shouldPreserveDuplicateAlgWhenReplacingJwk()
+      throws Exception {
+    try (TigerProxy manipulatingProxy = new TigerProxy(TigerProxyConfiguration.builder().build())) {
+      manipulatingProxy.configureJwtManipulation(
+          JwtManipulationConfiguration.builder()
+              .jwtLocation("$.body.client_assertion")
+              .jwtField("variant.name")
+              .replaceWith("duplicate_alg_headers")
+              .privateKeyPem(TEST_EC_PRIVATE_KEY_PEM)
+              .replaceJwk(true)
+              .build());
+
+      String originalJwt = createUnsignedJwt(Map.of("alg", "ES256"), Map.of("sub", "live-sub"));
+      HttpRequest manipulatedRequest = createClientAssertionFormRequest(originalJwt);
+
+      manipulatingProxy.applyJwtManipulationIfConfigured(manipulatedRequest);
+
+      String headerJson = decodeJwtHeaderAsText(extractClientAssertion(manipulatedRequest));
+      assertThat(headerJson.split("\"alg\"", -1)).hasSize(3);
+      assertThat(headerJson).contains("\"jwk\"");
+    }
+  }
+
+  /** Verify that removing the only JOSE header member still inserts a valid replacement JWK. */
+  @Test
+  void applyJwtManipulationIfConfigured_shouldReplaceJwkInMissingAlgEmptyHeader()
+      throws Exception {
+    try (TigerProxy manipulatingProxy = new TigerProxy(TigerProxyConfiguration.builder().build())) {
+      manipulatingProxy.configureJwtManipulation(
+          JwtManipulationConfiguration.builder()
+              .jwtLocation("$.body.client_assertion")
+              .jwtField("variant.name")
+              .replaceWith("missing_alg")
+              .privateKeyPem(TEST_EC_PRIVATE_KEY_PEM)
+              .replaceJwk(true)
+              .build());
+
+      String originalJwt = createUnsignedJwt(Map.of("alg", "ES256"), Map.of("sub", "live-sub"));
+      HttpRequest manipulatedRequest = createClientAssertionFormRequest(originalJwt);
+
+      manipulatingProxy.applyJwtManipulationIfConfigured(manipulatedRequest);
+
+      var header = OBJECT_MAPPER.readTree(decodeJwtHeaderAsText(
+          extractClientAssertion(manipulatedRequest)));
+      assertThat(header.has("alg")).isFalse();
+      assertThat(header.has("jwk")).isTrue();
+    }
+  }
+
+  private static final String TEST_EC_PRIVATE_KEY_PEM =
+      """
+      -----BEGIN PRIVATE KEY-----
+      MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCDm0+zJJrMu9MCs/yPY
+      d4iNEB2M6R/VJDe5EWcYG4iohw==
+      -----END PRIVATE KEY-----
+      """;
+
+  /** Create a compact unsigned JWT for focused header/body manipulation tests. */
+  private static String createUnsignedJwt(Map<String, Object> header, Map<String, Object> body)
+      throws Exception {
+    String headerB64 =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(OBJECT_MAPPER.writeValueAsBytes(header));
+    String bodyB64 =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(OBJECT_MAPPER.writeValueAsBytes(body));
+    String signatureB64 =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString("sig".getBytes(StandardCharsets.UTF_8));
+    return headerB64 + "." + bodyB64 + "." + signatureB64;
+  }
+
+  /** Create a form request containing a client_assertion JWT parameter. */
+  private static HttpRequest createClientAssertionFormRequest(String jwt) {
+    String formBody = "client_id=live-client&client_assertion="
+        + URLEncoder.encode(jwt, StandardCharsets.UTF_8);
+    return HttpRequest.request("/token")
+        .withHeader("Content-Type", "application/x-www-form-urlencoded")
+        .withBody(formBody.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /** Extract the decoded client_assertion form parameter from a request. */
+  private static String extractClientAssertion(HttpRequest request) {
+    String body = new String(request.getBody(), StandardCharsets.UTF_8);
+    for (String parameter : body.split("&")) {
+      String[] parts = parameter.split("=", 2);
+      if (parts.length == 2 && "client_assertion".equals(parts[0])) {
+        return URLDecoder.decode(parts[1], StandardCharsets.UTF_8);
+      }
+    }
+    throw new AssertionError("client_assertion parameter not found");
+  }
+
+  /** Extract the compact JWT portion from an Authorization header value. */
+  private static String extractJwtFromAuthorization(HttpRequest request) {
+    return extractJwtFromHeaderValue(request.getFirstHeader("Authorization"));
+  }
+
+  /** Extract the compact JWT portion from a header value with an optional auth scheme prefix. */
+  private static String extractJwtFromHeaderValue(String headerValue) {
+    int firstWhitespace = headerValue.indexOf(' ');
+    return firstWhitespace >= 0 ? headerValue.substring(firstWhitespace + 1) : headerValue;
+  }
+
+  /** Read a string claim from the JWT body for assertions. */
+  private static String extractBodyClaim(String jwt, String claim) throws Exception {
+    String[] parts = jwt.split("\\.");
+    String bodyJson = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+    return OBJECT_MAPPER.readTree(bodyJson).get(claim).asText();
+  }
+
+  /** Read a string claim from the JWT header for assertions. */
+  private static String extractHeaderClaim(String jwt, String claim) throws Exception {
+    return OBJECT_MAPPER.readTree(decodeJwtHeaderAsText(jwt)).get(claim).asText();
+  }
+
+  /** Decode the JWT header segment as UTF-8 text. */
+  private static String decodeJwtHeaderAsText(String jwt) {
+    String[] parts = jwt.split("\\.", -1);
+    return new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
+  }
+
+  /** Decode the JWT body segment as UTF-8 text. */
+  private static String decodeJwtBodyAsText(String jwt) {
+    String[] parts = jwt.split("\\.", -1);
+    return new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+  }
+
+  /** Calculate the DPoP {@code ath} value for the given compact access token. */
+  private static String calculateAth(String accessToken) throws Exception {
+    byte[] hash =
+        MessageDigest.getInstance("SHA-256").digest(accessToken.getBytes(StandardCharsets.US_ASCII));
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+  }
+}


### PR DESCRIPTION
## Summary

  Adds proxy-scoped JWT manipulation support to Tiger Proxy.

  The implementation introduces a `/manipulation/modifyJwt` endpoint that can configure JWT mutations for forwarded requests, including header/body
  JWT locations, claim replacement, optional re-signing, DPoP `ath` recalculation, malformed JWT variants, and execution limits.

  JWT manipulation state is stored on the `TigerProxy` instance so parallel proxy instances do not share global mutable state.

  ## Changes

  - Add JWT manipulation request/configuration DTOs
  - Add `ManipulationController` endpoint for JWT manipulation lifecycle
  - Apply configured JWT manipulation in forward and reverse proxy request handling
  - Add proxy-local JWT manipulation state and execution limit tracking
  - Use existing jose4j/JCA stack for EC/JWS signing instead of introducing Nimbus JOSE
  - Add focused tests for isolation, DPoP `ath`, variants, JWK replacement, and path/header handling

  ## Verification

  - `mvn -pl tiger-proxy -am -DskipTests compile`
  - `mvn -pl tiger-proxy -Dtest=TigerProxyJwtManipulationIsolationTest test`